### PR TITLE
Map side aggregation support

### DIFF
--- a/names.csv
+++ b/names.csv
@@ -1,0 +1,6 @@
+country
+brazil
+
+india
+india
+""

--- a/names.csv
+++ b/names.csv
@@ -1,6 +1,0 @@
-country
-brazil
-
-india
-india
-""

--- a/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
@@ -173,7 +173,7 @@ object RssOpts {
       .longConf
       .createWithDefault(5 * 1024 * 1024L)
   val enableDynamicMemoryAllocation: ConfigEntry[Boolean] =
-    ConfigBuilder("spark.shuffle.rss.mapSideAggregation.enabled")
+    ConfigBuilder("spark.shuffle.rss.mapSideAggregation.dynamicAllocation.enabled")
       .doc("When enabled, memory will be dynamically allocated for map side aggregation from the task memory manager.")
       .booleanConf
       .createWithDefault(true)

--- a/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
@@ -168,7 +168,7 @@ object RssOpts {
       .booleanConf
       .createWithDefault(false)
   val rssMapSideAggInitialMemoryThreshold: ConfigEntry[Long] =
-    ConfigBuilder("spark.rss.shuffle.spill.initialMemoryThreshold")
+    ConfigBuilder("spark.shuffle.rss.spill.initialMemoryThreshold")
       .doc("Initial memory to allocate each mapper for performing map side aggregation")
       .longConf
       .createWithDefault(5 * 1024 * 1024L)
@@ -176,7 +176,7 @@ object RssOpts {
     ConfigBuilder("spark.shuffle.rss.mapSideAggregation.dynamicAllocation.enabled")
       .doc("When enabled, memory will be dynamically allocated for map side aggregation from the task memory manager.")
       .booleanConf
-      .createWithDefault(true)
+      .createWithDefault(false)
   val reductionFactorBackoffMinRecords: ConfigEntry[Int] =
     ConfigBuilder("spark.shuffle.rss.mapSideAggregation.reductionFactorBackoffMinRecords")
       .doc("Minimum number of records to sample/process before checking reduction factor")

--- a/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
@@ -162,4 +162,14 @@ object RssOpts {
       .doc("the server hosts to exclude, separated by comma.")
       .stringConf
       .createWithDefault("")
+  val enableMapSideAggregation: ConfigEntry[Boolean] =
+    ConfigBuilder("spark.shuffle.rss.mapSideAggregation.enabled")
+      .doc("Enable Best effort map side aggregation")
+      .booleanConf
+      .createWithDefault(false)
+  val rssMapSideAggInitialMemoryThreshold: ConfigEntry[Int] =
+    ConfigBuilder("spark.rss.shuffle.spill.initialMemoryThreshold")
+      .doc("Initial memory to allocate each mapper for performing map side aggregation")
+      .intConf
+      .createWithDefault(5 * 1024 * 1024)
 }

--- a/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
@@ -177,6 +177,11 @@ object RssOpts {
       .doc("When enabled, memory will be dynamically allocated for map side aggregation from the task memory manager.")
       .booleanConf
       .createWithDefault(true)
+  val reductionFactorBackoffMinRecords: ConfigEntry[Int] =
+    ConfigBuilder("spark.shuffle.rss.mapSideAggregation.reductionFactorBackoffMinRecords")
+      .doc("Minimum number of records to sample/process before checking reduction factor")
+      .intConf
+      .createWithDefault(1000)
   val reductionFactorBackoffThreshold: ConfigEntry[Double] =
     ConfigBuilder("spark.shuffle.rss.mapSideAggregation.reductionFactorBackoffThreshold")
       .doc("Minimum reduction factor below which map side aggregation will be skipped")

--- a/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
@@ -177,4 +177,9 @@ object RssOpts {
       .doc("When enabled, memory will be dynamically allocated for map side aggregation from the task memory manager.")
       .booleanConf
       .createWithDefault(true)
+  val reductionFactorBackoffThreshold: ConfigEntry[Double] =
+    ConfigBuilder("spark.shuffle.rss.mapSideAggregation.reductionFactorBackoffThreshold")
+      .doc("Minimum reduction factor below which map side aggregation will be skipped")
+      .doubleConf
+      .createWithDefault(0.2)
 }

--- a/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
@@ -167,9 +167,14 @@ object RssOpts {
       .doc("Enable Best effort map side aggregation")
       .booleanConf
       .createWithDefault(false)
-  val rssMapSideAggInitialMemoryThreshold: ConfigEntry[Int] =
+  val rssMapSideAggInitialMemoryThreshold: ConfigEntry[Long] =
     ConfigBuilder("spark.rss.shuffle.spill.initialMemoryThreshold")
       .doc("Initial memory to allocate each mapper for performing map side aggregation")
-      .intConf
-      .createWithDefault(5 * 1024 * 1024)
+      .longConf
+      .createWithDefault(5 * 1024 * 1024L)
+  val enableDynamicMemoryAllocation: ConfigEntry[Boolean] =
+    ConfigBuilder("spark.shuffle.rss.mapSideAggregation.enabled")
+      .doc("When enabled, memory will be dynamically allocated for map side aggregation from the task memory manager.")
+      .booleanConf
+      .createWithDefault(true)
 }

--- a/src/main/scala/org/apache/spark/shuffle/RssShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssShuffleManager.scala
@@ -279,6 +279,7 @@ class RssShuffleManager(conf: SparkConf) extends ShuffleManager with Logging {
                 rssShuffleHandle.dependency,
                 shuffleClientStageMetrics,
                 context.taskMetrics().shuffleWriteMetrics,
+                context.taskMemoryManager(),
                 conf)
             } catch {
               case ex: Throwable => {

--- a/src/main/scala/org/apache/spark/shuffle/RssShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssShuffleManager.scala
@@ -278,7 +278,7 @@ class RssShuffleManager(conf: SparkConf) extends ShuffleManager with Logging {
                 bufferOptions,
                 rssShuffleHandle.dependency,
                 shuffleClientStageMetrics,
-                context.taskMetrics().shuffleWriteMetrics,
+                context.taskMetrics(),
                 context.taskMemoryManager(),
                 conf)
             } catch {

--- a/src/main/scala/org/apache/spark/shuffle/RssShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssShuffleManager.scala
@@ -278,7 +278,8 @@ class RssShuffleManager(conf: SparkConf) extends ShuffleManager with Logging {
                 bufferOptions,
                 rssShuffleHandle.dependency,
                 shuffleClientStageMetrics,
-                context.taskMetrics().shuffleWriteMetrics)
+                context.taskMetrics().shuffleWriteMetrics,
+                conf)
             } catch {
               case ex: Throwable => {
                 ExceptionUtils.closeWithoutException(writeClient)

--- a/src/main/scala/org/apache/spark/shuffle/RssShuffleWriter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssShuffleWriter.scala
@@ -130,18 +130,21 @@ class RssShuffleWriter[K, V, C](
     val finishUploadTime = System.nanoTime() - finishUploadStartTime
 
     val totalBytes = writeClient.getShuffleWriteBytes()
-    logInfo(s"Wrote shuffle records ($mapInfo), $numRecords records, $totalBytes bytes, write seconds: ${TimeUnit.NANOSECONDS.toSeconds(startUploadTime)}, ${TimeUnit.NANOSECONDS.toSeconds(writeRecordTime)}, ${TimeUnit.NANOSECONDS.toSeconds(finishUploadTime)}, serialize seconds: ${TimeUnit.NANOSECONDS.toSeconds(serializeTime)}, record fetch seconds: ${TimeUnit.NANOSECONDS.toSeconds(recordFetchTime)}")
 
     val writeMetrics = List(("mapSideCombine", shuffleDependency.mapSideCombine.toString),
-        ("reductionFactor", writerManager.reductionFactor.toString),
-        ("spillCount", writerManager.numberOfSpills.toString),
-        ("aggManager", writerManager.getClass.toString),
-        ("recordsWritten", writerManager.recordsWritten.toString))
-//    println("$$$$$$$$$")
-//    println(writeMetrics)
-//    println("$$$$$$$$$")
+      ("reductionFactor", writerManager.reductionFactor.toString),
+      ("spillCount", writerManager.numberOfSpills.toString),
+      ("aggManager", writerManager.getClass.toString),
+      ("recordsWritten", writerManager.recordsWritten.toString))
 
-    taskMetrics.addSupplementaryMetric(("shuffleWriteMetrics", SupplementaryMetric(writeMetrics)))
+    logInfo(s"Wrote shuffle records ($mapInfo), " +
+      s"$numRecords records, $totalBytes bytes, " +
+      s"write seconds: ${TimeUnit.NANOSECONDS.toSeconds(startUploadTime)}, " +
+      s"${TimeUnit.NANOSECONDS.toSeconds(writeRecordTime)}, " +
+      s"${TimeUnit.NANOSECONDS.toSeconds(finishUploadTime)}, " +
+      s"serialize seconds: ${TimeUnit.NANOSECONDS.toSeconds(serializeTime)}, " +
+      s"record fetch seconds: ${TimeUnit.NANOSECONDS.toSeconds(recordFetchTime)}," +
+      s"write metadata: ${writeMetrics.toString()}")
 
     shuffleWriteMetrics.incRecordsWritten(numRecords)
     shuffleWriteMetrics.incBytesWritten(totalBytes)

--- a/src/main/scala/org/apache/spark/shuffle/RssShuffleWriter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssShuffleWriter.scala
@@ -16,13 +16,12 @@ package org.apache.spark.shuffle
 
 import java.nio.ByteBuffer
 import java.util.concurrent.{CompletableFuture, TimeUnit}
-
 import com.uber.rss.clients.ShuffleDataWriter
 import com.uber.rss.common.{AppTaskAttemptId, ServerList}
 import com.uber.rss.exceptions.RssInvalidStateException
 import com.uber.rss.metrics.ShuffleClientStageMetrics
 import net.jpountz.lz4.LZ4Factory
-import org.apache.spark.ShuffleDependency
+import org.apache.spark.{ShuffleDependency, SparkConf}
 import org.apache.spark.executor.ShuffleWriteMetrics
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.MapStatus
@@ -39,7 +38,8 @@ class RssShuffleWriter[K, V, C](
     bufferOptions: BufferManagerOptions,
     shuffleDependency: ShuffleDependency[K, V, C],
     stageMetrics: ShuffleClientStageMetrics,
-    shuffleWriteMetrics: ShuffleWriteMetrics) extends ShuffleWriter[K, V] with Logging {
+    shuffleWriteMetrics: ShuffleWriteMetrics,
+    conf: SparkConf) extends ShuffleWriter[K, V] with Logging {
 
   logInfo(s"Using ShuffleWriter: ${this.getClass.getSimpleName}, map task: $mapInfo, buffer: $bufferOptions")
 

--- a/src/main/scala/org/apache/spark/shuffle/rss/RssStressTool.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/RssStressTool.scala
@@ -20,7 +20,6 @@ import java.util.Random
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import java.util.function.Consumer
-
 import com.uber.rss.clients._
 import com.uber.rss.common._
 import com.uber.rss.metadata.ServiceRegistry
@@ -28,7 +27,7 @@ import com.uber.rss.metrics.{M3Stats, ShuffleClientStageMetrics, ShuffleClientSt
 import com.uber.rss.storage.ShuffleFileStorage
 import com.uber.rss.{StreamServer, StreamServerConfig}
 import org.apache.commons.lang3.StringUtils
-import org.apache.spark.executor.ShuffleWriteMetrics
+import org.apache.spark.executor.{ShuffleWriteMetrics, TaskMetrics}
 import org.apache.spark.internal.Logging
 import org.apache.spark.serializer.KryoSerializer
 import org.apache.spark.shuffle.{MockTaskContext, RssOpts, RssShuffleReader, RssShuffleWriter}
@@ -327,7 +326,8 @@ class RssStressTool extends Logging {
       bufferOptions = BufferManagerOptions(writerBufferSize, 256 * 1024 * 1024, writerBufferSpill),
       shuffleDependency = shuffleDependency,
       stageMetrics = new ShuffleClientStageMetrics(new ShuffleClientStageMetricsKey("user1", "queue=1")),
-      shuffleWriteMetrics = new ShuffleWriteMetrics(),
+//      shuffleWriteMetrics = new ShuffleWriteMetrics(),
+      taskMetrics = new TaskMetrics(),
       new MockTaskContext(1, 0, taskAttemptIdSeed.incrementAndGet()).taskMemoryManager(),
       sparkConf
     )

--- a/src/main/scala/org/apache/spark/shuffle/rss/RssStressTool.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/RssStressTool.scala
@@ -328,6 +328,7 @@ class RssStressTool extends Logging {
       shuffleDependency = shuffleDependency,
       stageMetrics = new ShuffleClientStageMetrics(new ShuffleClientStageMetricsKey("user1", "queue=1")),
       shuffleWriteMetrics = new ShuffleWriteMetrics(),
+      new MockTaskContext(1, 0, taskAttemptIdSeed.incrementAndGet()).taskMemoryManager(),
       sparkConf
     )
 

--- a/src/main/scala/org/apache/spark/shuffle/rss/RssStressTool.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/RssStressTool.scala
@@ -327,7 +327,8 @@ class RssStressTool extends Logging {
       bufferOptions = BufferManagerOptions(writerBufferSize, 256 * 1024 * 1024, writerBufferSpill),
       shuffleDependency = shuffleDependency,
       stageMetrics = new ShuffleClientStageMetrics(new ShuffleClientStageMetricsKey("user1", "queue=1")),
-      shuffleWriteMetrics = new ShuffleWriteMetrics()
+      shuffleWriteMetrics = new ShuffleWriteMetrics(),
+      sparkConf
     )
 
     logInfo(s"Map $appMapId attempt $taskAttemptId started, write client: $writeClient")

--- a/src/main/scala/org/apache/spark/shuffle/rss/RssStressTool.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/RssStressTool.scala
@@ -326,7 +326,6 @@ class RssStressTool extends Logging {
       bufferOptions = BufferManagerOptions(writerBufferSize, 256 * 1024 * 1024, writerBufferSpill),
       shuffleDependency = shuffleDependency,
       stageMetrics = new ShuffleClientStageMetrics(new ShuffleClientStageMetricsKey("user1", "queue=1")),
-//      shuffleWriteMetrics = new ShuffleWriteMetrics(),
       taskMetrics = new TaskMetrics(),
       new MockTaskContext(1, 0, taskAttemptIdSeed.incrementAndGet()).taskMemoryManager(),
       sparkConf

--- a/src/main/scala/org/apache/spark/shuffle/rss/WriterAggregationImpl.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/WriterAggregationImpl.scala
@@ -112,7 +112,6 @@ private[rss] class WriterAggregationImpl[K, V, C](taskMemoryManager: TaskMemoryM
     val stream = serializerInstance.serializeStream(output)
 
     val itr = map.iterator
-    //ToDo: Skip map side aggregation based on the reduction factor
     while (itr.hasNext) {
       val item = itr.next()
       val (key, value): Product2[Any, Any] = (item._1._2, item._2)

--- a/src/main/scala/org/apache/spark/shuffle/rss/WriterAggregationImpl.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/WriterAggregationImpl.scala
@@ -1,0 +1,147 @@
+package org.apache.spark.shuffle.rss
+
+import com.esotericsoftware.kryo.io.Output
+import org.apache.spark.internal.Logging
+import org.apache.spark.{ShuffleDependency, SparkConf}
+import org.apache.spark.memory.{MemoryConsumer, MemoryMode, TaskMemoryManager}
+import org.apache.spark.serializer.Serializer
+import org.apache.spark.shuffle.RssOpts
+import org.apache.spark.util.collection.PartitionedAppendOnlyMap
+
+import scala.collection.mutable
+
+private[rss] class WriterAggregationImpl[K, V, C](taskMemoryManager: TaskMemoryManager,
+                                     shuffleDependency: ShuffleDependency[K, V, C],
+                                     serializer: Serializer,
+                                     bufferOptions: BufferManagerOptions,
+                                     conf: SparkConf)
+  extends MemoryConsumer(taskMemoryManager) with Logging {
+
+  private var map = new PartitionedAppendOnlyMap[K, C]
+  private var recordsWrittenCnt: Int = 0
+  private var forceSpill: Boolean = false
+  private var numberOfSpills: Int = 0
+
+  private val mergeValue = shuffleDependency.aggregator.get.mergeValue
+  private val createCombiner = shuffleDependency.aggregator.get.createCombiner
+  private var kv: Product2[K, V] = null
+  private val update = (hadValue: Boolean, oldValue: C) => {
+    if (hadValue) {
+      mergeValue(oldValue, kv._2)
+    } else {
+      createCombiner(kv._2)
+    }
+  }
+
+  private val initialMemoryThreshold: Long = conf.get(RssOpts.rssMapSideAggInitialMemoryThreshold)
+  private var allocatedMemoryThreshold: Long = initialMemoryThreshold
+  private val serializerInstance = serializer.newInstance()
+
+  private[rss] def recordsWritten: Int = recordsWrittenCnt
+
+  private def changeValue(key: (Int, K), updateFunc: (Boolean, C) => C): C = {
+    map.changeValue(key, updateFunc)
+  }
+
+  private[rss] def addRecord(partitionId: Int, record: Product2[K, V]): Seq[(Int, Array[Byte])] = {
+    kv = record
+    changeValue((partitionId, kv._1), update)
+    maybeSpillCollection()
+  }
+
+  private def maybeSpillCollection(): Seq[(Int, Array[Byte])] = {
+    if (forceSpill) {
+      val dataToSpill = spillMap()
+      forceSpill = false
+      dataToSpill
+    } else {
+      val estimatedSize = map.estimateSize()
+      val (spill, spilledData) = mayBeSpill(estimatedSize)
+      if (spill) {
+        spilledData
+      } else {
+        Seq.empty
+      }
+    }
+  }
+
+  private def mayBeSpill(currentMemory: Long): (Boolean, Seq[(Int, Array[Byte])])  = {
+    if (currentMemory >= allocatedMemoryThreshold) {
+      if (!tryToAllocateMemory(currentMemory)) {
+        logDebug(s"Exhausted allocated $allocatedMemoryThreshold memory. Spilling $currentMemory to RSS servers")
+        val result = spillMap()
+        (true, result)
+      } else {
+        (false, Seq.empty)
+      }
+    } else {
+      (false, Seq.empty)
+    }
+  }
+
+  def releaseMemory(memoryToHold: Long): Long = {
+    val memoryReleased = allocatedMemoryThreshold - memoryToHold
+    freeMemory(memoryReleased)
+    allocatedMemoryThreshold = memoryToHold
+    memoryReleased
+  }
+
+  private def tryToAllocateMemory(currentMemory: Long): Boolean = {
+    if (conf.get(RssOpts.enableDynamicMemoryAllocation)) {
+      val memoryToRequest = 2 * currentMemory - allocatedMemoryThreshold
+      val granted = acquireMemory(memoryToRequest)
+      allocatedMemoryThreshold += granted
+      currentMemory >= allocatedMemoryThreshold
+    } else {
+      false
+    }
+  }
+
+  private[rss] def spillMap(): Seq[(Int, Array[Byte])] = {
+    numberOfSpills += 1
+    val result = mutable.Buffer[(Int, Array[Byte])]()
+    val output = new Output(initialMemoryThreshold.toInt, bufferOptions.individualBufferMax)
+    val stream = serializerInstance.serializeStream(output)
+
+    val itr = map.iterator
+    //ToDo: Skip map side aggregation based on the reduction factor
+    while (itr.hasNext) {
+      val item = itr.next()
+      val (key, value): Product2[Any, Any] = (item._1._2, item._2)
+      stream.writeKey(key)
+      stream.writeValue(value)
+      stream.flush()
+      result.append((item._1._1, output.toBytes))
+      output.clear()
+      recordsWrittenCnt += 1
+    }
+    stream.close()
+    map = new PartitionedAppendOnlyMap[K, C]
+    result
+  }
+
+  private[rss] def filledBytes: Int = {
+    if (map.isEmpty) {
+      0
+    } else {
+      map.estimateSize().toInt
+    }
+  }
+
+  override def spill(size: Long, trigger: MemoryConsumer): Long = {
+    if (taskMemoryManager.getTungstenMemoryMode == MemoryMode.ON_HEAP) {
+      val dataToSpill = spillMap()
+      if (!dataToSpill.isEmpty) {
+        // set forceSpill so that the data will be force spilled whenever new record is to be written
+        forceSpill = true
+        // ToDo: This memory will be released when the next record is processed and after sendDataBlock
+        //  has been called. Will this cause issues?
+        val memoryToBeReleased = allocatedMemoryThreshold - initialMemoryThreshold
+        memoryToBeReleased
+      } else {
+        0L
+      }
+    } else {
+      0L
+    }
+  }}

--- a/src/main/scala/org/apache/spark/shuffle/rss/WriterAggregationImpl.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/WriterAggregationImpl.scala
@@ -34,9 +34,10 @@ private[rss] class WriterAggregationImpl[K, V, C](taskMemoryManager: TaskMemoryM
   }
 
   private val initialMemoryThreshold: Long = conf.get(RssOpts.rssMapSideAggInitialMemoryThreshold)
-  private var allocatedMemoryThreshold: Long = initialMemoryThreshold
   private val serializerInstance = serializer.newInstance()
+  private var allocatedMemoryThreshold: Long = initialMemoryThreshold
 
+  private[rss] def mapSize: Int = map.size
   private[rss] def recordsWritten: Int = recordsWrittenCnt
 
   private def changeValue(key: (Int, K), updateFunc: (Boolean, C) => C): C = {

--- a/src/main/scala/org/apache/spark/shuffle/rss/WriterAggregationManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/WriterAggregationManager.scala
@@ -53,8 +53,6 @@ class WriterAggregationManager[K, V, C](taskMemoryManager: TaskMemoryManager,
   private val aggImpl = new WriterAggregationImpl(taskMemoryManager,
     shuffleDependency, serializer, bufferOptions, conf)
 
-  logInfo(">>> Using the custom map side aggregation in RSS")
-
   private var aggMapper: WriterAggregationMapper[K, V, C] = null
 
   override def recordsWritten: Int = if (skipMapSideAgg) {
@@ -93,13 +91,7 @@ class WriterAggregationManager[K, V, C](taskMemoryManager: TaskMemoryManager,
       0.0
     } else {
       val recordsCountPostAgg = recordsWritten + aggImpl.mapSize
-      val a = 1 - (recordsCountPostAgg / recordsRead.toDouble)
-//      logInfo(">>>>>>>>")
-//      logInfo(s"mapSize ${recordsWritten + aggImpl.mapSize}")
-//      logInfo(s"recordsRead ${recordsRead.toString}")
-//      logInfo(s"Reduction Factor ${a.toString}")
-//      logInfo(">>>>>>>>")
-      a
+      1.0 - (recordsCountPostAgg / recordsRead.toDouble)
     }
   }
 

--- a/src/main/scala/org/apache/spark/shuffle/rss/WriterAggregationManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/WriterAggregationManager.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2020 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.rss
+
+import com.esotericsoftware.kryo.io.Output
+import org.apache.spark.{ShuffleDependency, SparkConf, SparkEnv}
+import org.apache.spark.internal.Logging
+import org.apache.spark.serializer.Serializer
+import org.apache.spark.shuffle.RssOpts
+import org.apache.spark.util.collection.PartitionedAppendOnlyMap
+
+import scala.collection.mutable
+
+//ToDo: Fix/Check number of bytes written
+/**
+ * Does a best effort map side aggregation. Even if the partial aggregation is not complete, reducer side combiners
+ * will take of aggregating the partially aggregated results within the mapper partition.
+ * [[org.apache.spark.util.collection.PartitionedAppendOnlyMap]]'s
+ * map implementation is used since it provides a functionality to estimate the size of the map.
+ * To make the keys compatible with PartitionedAppendOnlyMap, each key is of the format (partitionId, aggKey).
+ *
+ * The map can grow up to the size of up to [[RssOpts.rssMapSideAggInitialMemoryThreshold]], Once the
+ * allocated memory is exhausted, data is spilled (sent to RSS servers).
+ */
+class WriterAggregationManager[K, V, C](shuffleDependency: ShuffleDependency[K, V, C],
+                                        serializer: Serializer,
+                                        bufferOptions: BufferManagerOptions,
+                                        conf: SparkConf)
+  extends WriteBufferManager[K, V, C](serializer, bufferOptions) with Logging {
+
+  var map = new PartitionedAppendOnlyMap[K, C]
+  var recordsWrittenCnt: Int = 0
+  override def recordsWritten: Int = recordsWrittenCnt
+
+  var numberOfSpills: Int = 0
+
+  private val mergeValue = shuffleDependency.aggregator.get.mergeValue
+  private val createCombiner = shuffleDependency.aggregator.get.createCombiner
+  private var kv: Product2[K, V] = null
+  val update = (hadValue: Boolean, oldValue: C) => {
+    if (hadValue) {
+      mergeValue(oldValue, kv._2)
+    } else {
+      createCombiner(kv._2)
+    }
+  }
+
+  //ToDo: Allocate memory dynamically
+  private[this] val initialMemoryThreshold: Int = conf.get(RssOpts.rssMapSideAggInitialMemoryThreshold)
+
+  private val serializerInstance = serializer.newInstance()
+
+  private def changeValue(key: (Int, K), updateFunc: (Boolean, C) => C): C = {
+    map.changeValue(key, updateFunc)
+  }
+
+  override def addRecord(partitionId: Int, record: Product2[K, V]): Seq[(Int, Array[Byte])] = {
+    kv = record
+    changeValue((partitionId, kv._1), update)
+    maybeSpillCollection()
+  }
+
+  private def maybeSpillCollection(): Seq[(Int, Array[Byte])] = {
+    val estimatedSize = map.estimateSize()
+    val (spill, spilledData) = mayBeSpill(estimatedSize)
+    if (spill) {
+      spilledData
+    } else {
+      Seq.empty
+    }
+  }
+
+  private def mayBeSpill(currentMemory: Long): (Boolean, Seq[(Int, Array[Byte])])  = {
+    if (currentMemory > initialMemoryThreshold) {
+      logDebug(s"Exhausted allocated $initialMemoryThreshold memory. Spilling $currentMemory to RSS servers")
+      val result = spillMap()
+      (true, result)
+    } else {
+      (false, Seq.empty)
+    }
+  }
+
+  private def spillMap(): Seq[(Int, Array[Byte])] = {
+    numberOfSpills += 1
+    val result = mutable.Buffer[(Int, Array[Byte])]()
+    val output = new Output(initialMemoryThreshold, bufferOptions.individualBufferMax)
+    val stream = serializerInstance.serializeStream(output)
+
+    val itr = map.iterator
+    //ToDo: Skip map side aggregation based on the reduction factor
+    while (itr.hasNext) {
+      val item = itr.next()
+      val (key, value): Product2[Any, Any] = (item._1._2, item._2)
+      stream.writeKey(key)
+      stream.writeValue(value)
+      stream.flush()
+      result.append((item._1._1, output.toBytes))
+      output.clear()
+      recordsWrittenCnt += 1
+    }
+    stream.close()
+    map = new PartitionedAppendOnlyMap[K, C]
+    result
+  }
+
+  override def clear(): Seq[(Int, Array[Byte])] = {
+    val result = spillMap()
+    result
+  }
+
+  override def filledBytes: Int = {
+    if (map.isEmpty) {
+      0
+    } else {
+      map.estimateSize().toInt
+    }
+  }
+}

--- a/src/main/scala/org/apache/spark/shuffle/rss/WriterAggregationMapper.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/WriterAggregationMapper.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.rss
+
+import org.apache.spark.{ShuffleDependency, SparkConf}
+import org.apache.spark.internal.Logging
+import org.apache.spark.serializer.Serializer
+
+/**
+ * Only maps each input row to the output type of the combiner. This is logically
+ * equivalent of map side aggregation with reduction factor as 0.
+ */
+class WriterAggregationMapper[K, V, C](shuffleDependency: ShuffleDependency[K, V, C],
+                                       serializer: Serializer,
+                                       bufferOptions: BufferManagerOptions)
+  extends WriteBufferManager[K, V, C](serializer, bufferOptions) with Logging {
+
+  private val createCombiner = shuffleDependency.aggregator.get.createCombiner
+
+  override def addRecord(partitionId: Int, record: Product2[K, V]): Seq[(Int, Array[Byte])] = {
+    val combinedValue = createCombiner(record._2)
+    addRecordImpl(partitionId, (record._1, combinedValue))
+  }
+}

--- a/src/main/scala/org/apache/spark/shuffle/rss/WriterBufferManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/WriterBufferManager.scala
@@ -109,4 +109,6 @@ class WriteBufferManager[K, V, C](serializer: Serializer,
     totalBytes = 0
     result
   }
+
+  def releaseMemory(memoryToHold: Long = 0L): Unit = {}
 }

--- a/src/main/scala/org/apache/spark/shuffle/rss/WriterBufferManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/WriterBufferManager.scala
@@ -26,18 +26,32 @@ case class BufferManagerOptions(individualBufferSize: Int, individualBufferMax: 
 
 case class WriterBufferManagerValue(serializeStream: SerializationStream, output: Output)
 
-class WriteBufferManager(serializer: Serializer,
+class WriteBufferManager[K, V, C](serializer: Serializer,
                                bufferSize: Int,
                                maxBufferSize: Int,
                                spillSize: Int) extends Logging {
+
+  def this(serializer: Serializer, bufferOptions: BufferManagerOptions) {
+    this(serializer, bufferOptions.individualBufferSize,
+      bufferOptions.individualBufferMax, bufferOptions.bufferSpillThreshold)
+  }
+
   private val map: Map[Int, WriterBufferManagerValue] = Map()
 
   private var totalBytes = 0
 
+  def recordsWritten: Int = recordsWrittenCount
+
+  var recordsWrittenCount: Int = 0
+
+  def addRecord(partitionId: Int, record: Product2[K, V]): Seq[(Int, Array[Byte])] = {
+    addRecordImpl(partitionId, record)
+  }
   private val serializerInstance = serializer.newInstance()
 
-  def addRecord(partitionId: Int, record: Product2[Any, Any]): Seq[(Int, Array[Byte])] = {
+  private[rss] def addRecordImpl(partitionId: Int, record: Product2[Any, Any]): Seq[(Int, Array[Byte])] = {
     val result = mutable.Buffer[(Int, Array[Byte])]()
+    recordsWrittenCount += 1
     map.get(partitionId) match {
       case Some(v) =>
         val stream = v.serializeStream
@@ -80,7 +94,7 @@ class WriteBufferManager(serializer: Serializer,
     result
   }
 
-  def filledBytes = {
+  def filledBytes: Int = {
     val sum = map.map(_._2.output.position()).sum
     if (sum != totalBytes) {
       throw new RssInvalidDataException(s"Inconsistent internal state, total bytes is $totalBytes, but should be $sum")

--- a/src/test/scala/org/apache/spark/shuffle/ShuffleWithAggregationTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/ShuffleWithAggregationTest.scala
@@ -34,6 +34,8 @@ class ShuffleWithAggregationTest {
   var sc: SparkContext = null
   
   var rssTestCluster: RssMiniCluster = null
+
+  val globalConf = List("spark.sql.autoBroadcastJoinThreshold", "-1")
   
   @BeforeMethod
   def beforeTestMethod(): Unit = {
@@ -76,6 +78,7 @@ class ShuffleWithAggregationTest {
     Seq("true", "false").foreach(confValue => {
       val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
       conf.set("spark.shuffle.rss.mapSideAggregation.enabled", confValue)
+      conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
       sc = new SparkContext(conf)
 
       val numValues = 1000
@@ -108,6 +111,7 @@ class ShuffleWithAggregationTest {
     Seq("true", "false").foreach(confValue => {
       val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
       conf.set("spark.shuffle.rss.mapSideAggregation.enabled", confValue)
+      conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
       sc = new SparkContext(conf)
 
       val numValues = 1000
@@ -141,6 +145,7 @@ class ShuffleWithAggregationTest {
       val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
       conf.set("spark.shuffle.rss.mapSideAggregation.enabled", "false")
       conf.set("spark.shuffle.rss.mapSideAggregation.dynamicAllocation.enabled", confValue)
+      conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
       sc = new SparkContext(conf)
 
       val numValues = 1000
@@ -165,6 +170,7 @@ class ShuffleWithAggregationTest {
       conf.set("spark.shuffle.rss.mapSideAggregation.enabled", "true")
       conf.set("spark.shuffle.rss.mapSideAggregation.reductionFactorBackoffMinRecords", "10")
       conf.set("spark.shuffle.rss.mapSideAggregation.reductionFactorBackoffThreshold", "1.0")
+      conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
       sc = new SparkContext(conf)
 
       val numValues = 1000
@@ -192,6 +198,7 @@ class ShuffleWithAggregationTest {
       val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
       conf.set("spark.shuffle.rss.mapSideAggregation.dynamicAllocation.enabled", confValue)
       conf.set("spark.shuffle.rss.mapSideAggregation.enabled", "true")
+      conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
       sc = new SparkContext(conf)
 
       val numValues = 1000
@@ -214,7 +221,8 @@ class ShuffleWithAggregationTest {
     conf.set("spark.shuffle.rss.mapSideAggregation.dynamicAllocation.enabled", "true")
     conf.set("spark.shuffle.rss.mapSideAggregation.enabled", "true")
     // Allocate very little memory so that dynamic allocation gets triggered
-    conf.set("spark.rss.shuffle.spill.initialMemoryThreshold", "5")
+    conf.set("spark.shuffle.rss.spill.initialMemoryThreshold", "5")
+    conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
     sc = new SparkContext(conf)
 
     val numValues = 1000
@@ -229,37 +237,4 @@ class ShuffleWithAggregationTest {
     assert(shuffleRecordsWritten == 500)
     assert(shuffleRecordsRead == 500)
   }
-
-//  @Test
-//  def nullValueTest(): Unit = {
-//    val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
-//    conf.set("spark.shuffle.rss.mapSideAggregation.dynamicAllocation.enabled", "true")
-//    conf.set("spark.shuffle.rss.mapSideAggregation.enabled", "true")
-//    // Allocate very little memory so that dynamic allocation gets triggered
-//    conf.set("spark.rss.shuffle.spill.initialMemoryThreshold", "5")
-//    sc = new SparkContext(conf)
-//
-//    val numValues = 1000
-//    val numPartitions = 10
-//
-//    val seq = Seq(1, 2, null, 3, 4, 5, 6, 7, null, 8, 9, 10, null)
-//
-//    val path = "/Users/mayurb/src/open/RemoteShuffleService/names.csv"
-//    import org.apache.spark.sql.SQLContext
-//    val sqlContext = new SQLContext(sc)
-//    val spark = SparkSession.builder().sparkContext(sc).getOrCreate()
-//    val peopleDf = spark.read.option("header", "true").csv(path)
-//    val rdd = peopleDf.toDF().rdd
-//
-//
-//    val result = rdd
-//      .repartition(2)
-//      .map(t => t.toString())
-//      .reduce((x:String, y: String) => x + y)
-//
-////    val shuffleRecordsWritten = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleWriteMetrics.recordsWritten)
-////    val shuffleRecordsRead = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleReadMetrics.recordsRead)
-////    assert(shuffleRecordsWritten == 500)
-////    assert(shuffleRecordsRead == 500)
-//  }
 }

--- a/src/test/scala/org/apache/spark/shuffle/ShuffleWithAggregationTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/ShuffleWithAggregationTest.scala
@@ -15,9 +15,7 @@
 package org.apache.spark.shuffle
 
 import java.util.UUID
-
 import com.uber.rss.testutil.{RssMiniCluster, RssZookeeperCluster, StreamServerTestUtils}
-
 import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
 import org.apache.spark.SparkContext
 import org.scalatest.Assertions._
@@ -231,4 +229,37 @@ class ShuffleWithAggregationTest {
     assert(shuffleRecordsWritten == 500)
     assert(shuffleRecordsRead == 500)
   }
+
+//  @Test
+//  def nullValueTest(): Unit = {
+//    val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
+//    conf.set("spark.shuffle.rss.mapSideAggregation.dynamicAllocation.enabled", "true")
+//    conf.set("spark.shuffle.rss.mapSideAggregation.enabled", "true")
+//    // Allocate very little memory so that dynamic allocation gets triggered
+//    conf.set("spark.rss.shuffle.spill.initialMemoryThreshold", "5")
+//    sc = new SparkContext(conf)
+//
+//    val numValues = 1000
+//    val numPartitions = 10
+//
+//    val seq = Seq(1, 2, null, 3, 4, 5, 6, 7, null, 8, 9, 10, null)
+//
+//    val path = "/Users/mayurb/src/open/RemoteShuffleService/names.csv"
+//    import org.apache.spark.sql.SQLContext
+//    val sqlContext = new SQLContext(sc)
+//    val spark = SparkSession.builder().sparkContext(sc).getOrCreate()
+//    val peopleDf = spark.read.option("header", "true").csv(path)
+//    val rdd = peopleDf.toDF().rdd
+//
+//
+//    val result = rdd
+//      .repartition(2)
+//      .map(t => t.toString())
+//      .reduce((x:String, y: String) => x + y)
+//
+////    val shuffleRecordsWritten = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleWriteMetrics.recordsWritten)
+////    val shuffleRecordsRead = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleReadMetrics.recordsRead)
+////    assert(shuffleRecordsWritten == 500)
+////    assert(shuffleRecordsRead == 500)
+//  }
 }

--- a/src/test/scala/org/apache/spark/shuffle/rss/WriteBufferManagerTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/rss/WriteBufferManagerTest.scala
@@ -38,7 +38,7 @@ class WriteBufferManagerTest {
     Assert.assertEquals(spilledData.size, 0)
 
     val partition1 = 1
-    spilledData = bufferManager.addRecord(partition1, record).toList
+    spilledData = bufferManager.addRecordImpl(partition1, record).toList
     Assert.assertEquals(spilledData.size, 1)
     Assert.assertEquals(bufferManager.filledBytes, 0)
 
@@ -50,26 +50,26 @@ class WriteBufferManagerTest {
     spilledData = bufferManager.clear().toList
     Assert.assertEquals(spilledData.size, 0)
 
-    spilledData = bufferManager.addRecord(partition1, record).toList
+    spilledData = bufferManager.addRecordImpl(partition1, record).toList
     Assert.assertEquals(spilledData.size, 0)
     Assert.assertTrue(bufferManager.filledBytes > 0)
 
-    spilledData = bufferManager.addRecord(partition1, record).toList
+    spilledData = bufferManager.addRecordImpl(partition1, record).toList
     Assert.assertEquals(spilledData.size, 0)
 
-    spilledData = bufferManager.addRecord(partition1, record).toList
+    spilledData = bufferManager.addRecordImpl(partition1, record).toList
     Assert.assertEquals(spilledData.size, 1)
 
     Assert.assertEquals(bufferManager.filledBytes, 0)
 
-    spilledData = bufferManager.addRecord(partition1, record).toList
+    spilledData = bufferManager.addRecordImpl(partition1, record).toList
     Assert.assertEquals(spilledData.size, 0)
     Assert.assertTrue(bufferManager.filledBytes > 0)
 
-    spilledData = bufferManager.addRecord(partition1, record).toList
+    spilledData = bufferManager.addRecordImpl(partition1, record).toList
     Assert.assertEquals(spilledData.size, 0)
 
-    spilledData = bufferManager.addRecord(partition1, record).toList
+    spilledData = bufferManager.addRecordImpl(partition1, record).toList
     Assert.assertEquals(spilledData.size, 1)
 
     Assert.assertEquals(bufferManager.filledBytes, 0)
@@ -90,19 +90,19 @@ class WriteBufferManagerTest {
     val partition1 = 1
     val partition2 = 2
     val record = (1, "123") // it is 7 bytes after serialization
-    spilledData = bufferManager.addRecord(partition1, record).toList
+    spilledData = bufferManager.addRecordImpl(partition1, record).toList
     Assert.assertEquals(spilledData.size, 0)
     Assert.assertTrue(bufferManager.filledBytes > 0)
 
-    spilledData = bufferManager.addRecord(partition2, record).toList
+    spilledData = bufferManager.addRecordImpl(partition2, record).toList
     Assert.assertEquals(spilledData.size, 0)
 
-    spilledData = bufferManager.addRecord(partition1, record).toList
+    spilledData = bufferManager.addRecordImpl(partition1, record).toList
     Assert.assertEquals(spilledData.size, 0)
 
     val filledBytes1 = bufferManager.filledBytes
 
-    spilledData = bufferManager.addRecord(partition1, record).toList
+    spilledData = bufferManager.addRecordImpl(partition1, record).toList
     Assert.assertEquals(spilledData.size, 1)
     Assert.assertTrue(bufferManager.filledBytes < filledBytes1)
     Assert.assertTrue(bufferManager.filledBytes > 0)
@@ -118,14 +118,14 @@ class WriteBufferManagerTest {
     val partition2 = 2
     val partition3 = 3
     val record = (1, "123") // it is 7 bytes after serialization
-    var spilledData = bufferManager.addRecord(partition1, record).toList
+    var spilledData = bufferManager.addRecordImpl(partition1, record).toList
     Assert.assertEquals(spilledData.size, 0)
     Assert.assertTrue(bufferManager.filledBytes > 0)
 
-    spilledData = bufferManager.addRecord(partition2, record).toList
+    spilledData = bufferManager.addRecordImpl(partition2, record).toList
     Assert.assertEquals(spilledData.size, 0)
 
-    spilledData = bufferManager.addRecord(partition3, record).toList
+    spilledData = bufferManager.addRecordImpl(partition3, record).toList
     Assert.assertEquals(spilledData.size, 3)
     Assert.assertEquals(spilledData.map(_._1).sorted, Seq(partition1, partition2, partition3))
     Assert.assertEquals(bufferManager.filledBytes, 0)
@@ -147,7 +147,7 @@ class WriteBufferManagerTest {
     (0 until numRecords).foreach(_ => {
       val partition = partitions(random.nextInt(partitions.size))
       val record = records(random.nextInt(records.size))
-      val spilledData = bufferManager.addRecord(partition, record)
+      val spilledData = bufferManager.addRecordImpl(partition, record)
 
       Assert.assertTrue(bufferManager.filledBytes < spillSize)
       Assert.assertTrue(bufferManager.filledBytes >= 0)


### PR DESCRIPTION
Does a best effort map side aggregation meaning that it is not always guaranteed that all the values within mapper are combined. Even if the partial aggregation is not complete, reducer side combiners will take of aggregating the partially aggregated results within the mapper partition. 

org.apache.spark.util.collection.PartitionedAppendOnlyMap's map implementation is used since it provides a functionality to estimate the size of the map. To make the keys compatible with PartitionedAppendOnlyMap, each key is of the format 

The map can initially grow up to the size of up to [[RssOpts.rssMapSideAggInitialMemoryThreshold]], post that twice the memory
deficit is requested from the task memory manager every time the allocated quota is exhausted. If the memory is not allocated the data is spilled (sent to RSS servers)