### PR TITLE
Map Side aggregation support in RSS

### DIFF
--- a/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
@@ -162,4 +162,14 @@ object RssOpts {
       .doc("the server hosts to exclude, separated by comma.")
       .stringConf
       .createWithDefault("")
+  val enableMapSideAggregation: ConfigEntry[Boolean] =
+    ConfigBuilder("spark.shuffle.rss.mapSideAggregation.enabled")
+      .doc("Enable Best effort map side aggregation")
+      .booleanConf
+      .createWithDefault(false)
+  val initialMemoryThresholdInBytes: ConfigEntry[Long] =
+    ConfigBuilder("spark.shuffle.rss.mapSideAggregation.initialMemoryThresholdInBytes")
+      .doc("Initial memory to allocate each mapper for performing map side aggregation")
+      .longConf
+      .createWithDefault(5 * 1024 * 1024L)
 }

--- a/src/main/scala/org/apache/spark/shuffle/RssShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssShuffleManager.scala
@@ -280,7 +280,8 @@ class RssShuffleManager(conf: SparkConf) extends ShuffleManager with Logging {
                 bufferOptions,
                 rssShuffleHandle.dependency,
                 shuffleClientStageMetrics,
-                context.taskMetrics().shuffleWriteMetrics)
+                context.taskMetrics().shuffleWriteMetrics,
+                conf)
             } catch {
               case ex: Throwable => {
                 ExceptionUtils.closeWithoutException(writeClient)

--- a/src/main/scala/org/apache/spark/shuffle/rss/RssStressTool.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/RssStressTool.scala
@@ -327,7 +327,8 @@ class RssStressTool extends Logging {
       bufferOptions = BufferManagerOptions(writerBufferSize, 256 * 1024 * 1024, writerBufferSpill),
       shuffleDependency = shuffleDependency,
       stageMetrics = new ShuffleClientStageMetrics(new ShuffleClientStageMetricsKey("user1", "queue=1")),
-      shuffleWriteMetrics = new ShuffleWriteMetrics()
+      shuffleWriteMetrics = new ShuffleWriteMetrics(),
+      conf = sparkConf
     )
 
     logInfo(s"Map $appMapId attempt $taskAttemptId started, write client: $writeClient")

--- a/src/main/scala/org/apache/spark/shuffle/rss/WriterAggregationImpl.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/WriterAggregationImpl.scala
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2020 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.rss
+
+import com.esotericsoftware.kryo.io.Output
+import org.apache.spark.internal.Logging
+import org.apache.spark.{ShuffleDependency, SparkConf}
+import org.apache.spark.serializer.Serializer
+import org.apache.spark.shuffle.RssOpts
+import org.apache.spark.util.collection.PartitionedAppendOnlyMap
+
+import scala.collection.mutable
+
+/**
+ * Does a best effort map side aggregation. Even if the partial aggregation is not complete, reducer side combiners
+ * will take of aggregating the partially aggregated results within the mapper partition.
+ * [[org.apache.spark.util.collection.PartitionedAppendOnlyMap]]'s
+ * map implementation is used since it provides a functionality to estimate the size of the map.
+ * To make the keys compatible with PartitionedAppendOnlyMap, each key is of the format (partitionId, aggKey).
+ *
+ * The map can grow up to the size of up to [[RssOpts.initialMemoryThresholdInBytes]], Once the
+ * allocated memory is exhausted, data is spilled (sent to RSS servers).
+ */
+private[rss] class WriterAggregationImpl[K, V, C](shuffleDependency: ShuffleDependency[K, V, C],
+                                                  serializer: Serializer,
+                                                  bufferOptions: BufferManagerOptions,
+                                                  conf: SparkConf) extends Logging {
+
+  private var map = new PartitionedAppendOnlyMap[K, C]
+  private var recordsWrittenCnt: Int = 0
+
+  private val mergeValue = shuffleDependency.aggregator.get.mergeValue
+  private val createCombiner = shuffleDependency.aggregator.get.createCombiner
+  private var currentRecord: Product2[K, V] = null
+
+  private def update(hadValue: Boolean, oldValue: C): C = {
+    if (hadValue) {
+      mergeValue(oldValue, currentRecord._2)
+    } else {
+      createCombiner(currentRecord._2)
+    }
+  }
+
+  // Before sending the map output values from the `PartitionedAppendOnlyMap` to RSS servers,
+  // they are buffered (see `spillMap.result[mutable.Buffer]`).
+  // The size of this buffer is roughly 1/10th the estimated size of the PartitionedAppendOnlyMap
+  // So to be on the safe side, we consume only half the threshold map size
+  private val initialMemoryThreshold: Long = conf.get(RssOpts.initialMemoryThresholdInBytes) / 2
+  private val serializerInstance = serializer.newInstance()
+
+  private[rss] def numberOfRecordsInMap: Int = map.size
+  private[rss] def recordsWritten: Int = recordsWrittenCnt
+
+  private def changeValue(key: (Int, K), updateFunc: (Boolean, C) => C): C = map.changeValue(key, updateFunc)
+
+  /**
+   * Checks if the record with key, `(partitionId, aggregationKey)` is present in the map and if it does,
+   * merge it with the existing value in the map for that key.
+   */
+  private[rss] def addRecord(partitionId: Int, record: Product2[K, V]): Seq[(Int, Array[Byte])] = {
+    currentRecord = record
+    changeValue((partitionId, currentRecord._1), update)
+    spillIfRequired()
+  }
+
+
+  private def spillIfRequired(): Seq[(Int, Array[Byte])] = {
+    val estimatedSize = map.estimateSize()
+    if (estimatedSize >= initialMemoryThreshold) {
+      spillMap()
+    } else {
+      Seq.empty
+    }
+  }
+
+  /**
+   * Each entry in the hashmap is of the format,
+   * (partitionId, aggregationKey) -> value
+   *
+   * First, sort the hashmap by the partition ID,
+   * (partitionId<1>, (aggregationKey<1>, value)), (partitionId<1>, (aggregationKey<2>, value)),
+   * (partitionId<2>, (aggregationKey<1>, value)), .....
+   *
+   * Then, combine all the values of each partition, serialize them and return,
+   * [(partition1, Byte Array of serialized records for partition 1),
+   *  (partition2, Byte Array of serialized records for partition 2),
+   *  .....]
+   */
+  private[rss] def spillMap(): Seq[(Int, Array[Byte])] = {
+    val result = mutable.Buffer[(Int, Array[Byte])]()
+    val output = new Output(initialMemoryThreshold.toInt, bufferOptions.individualBufferMax)
+    val stream = serializerInstance.serializeStream(output)
+    try {
+      // Sort the data only by the partition ID
+      val partitionItr = getGroupedPartitionIterator(map.partitionedDestructiveSortedIterator(None))
+      // Iterate over partitions
+      while (partitionItr.hasNext) {
+        val nxt = partitionItr.next()
+        val partition = nxt._1
+        // Iterate over all values for a given partition
+        val recordItr = nxt._2
+        while (recordItr.hasNext) {
+          val item = recordItr.next()
+          val (key, value): Product2[Any, Any] = (item._1, item._2)
+          stream.writeKey(key)
+          stream.writeValue(value)
+          recordsWrittenCnt += 1
+        }
+        stream.flush()
+        result.append((partition, output.toBytes))
+        output.clear()
+      }
+    } catch {
+      case e: Throwable =>
+        logError(s"Error while spilling the hashmap: ${e.getMessage}")
+        result.clear()
+        throw e
+    } finally {
+      stream.close()
+      map = new PartitionedAppendOnlyMap[K, C]
+    }
+    result
+  }
+
+  private def getGroupedPartitionIterator(data: Iterator[((Int, K), C)]) : Iterator[(Int, Iterator[Product2[K, C]])] = {
+    val buffered = data.buffered
+    val numPartitions = shuffleDependency.partitioner.numPartitions
+    (0 until numPartitions).iterator.map(p => (p, new IteratorForPartition(p, buffered)))
+  }
+
+  private[this] class IteratorForPartition(partitionId: Int, data: BufferedIterator[((Int, K), C)])
+    extends Iterator[Product2[K, C]]
+  {
+    override def hasNext: Boolean = data.hasNext && data.head._1._1 == partitionId
+
+    override def next(): Product2[K, C] = {
+      if (!hasNext) {
+        throw new NoSuchElementException
+      }
+      val elem = data.next()
+      (elem._1._2, elem._2)
+    }
+  }
+
+  private[rss] def collectionSizeInBytes: Int = {
+    if (map.isEmpty) {
+      0
+    } else {
+      map.estimateSize().toInt
+    }
+  }
+}

--- a/src/main/scala/org/apache/spark/shuffle/rss/WriterAggregationManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/WriterAggregationManager.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.rss
+
+import org.apache.spark.{ShuffleDependency, SparkConf}
+import org.apache.spark.internal.Logging
+import org.apache.spark.serializer.Serializer
+
+/**
+ * An aggregation manager which tries to do a best effort map side aggregation.
+ * See [[org.apache.spark.shuffle.rss.WriterAggregationImpl]]
+ *
+ * In future, this abstraction will be used to fallback to
+ * [[org.apache.spark.shuffle.rss.WriterNoAggregationManager]] when the reduction
+ * factor is very low.
+ */
+class WriterAggregationManager[K, V, C](shuffleDependency: ShuffleDependency[K, V, C],
+                                        serializer: Serializer,
+                                        bufferOptions: BufferManagerOptions,
+                                        conf: SparkConf)
+  extends WriteBufferManager[K, V, C](serializer, bufferOptions) with Logging {
+
+  private var recordsRead: Int = 0
+
+  private val aggImpl = new WriterAggregationImpl(shuffleDependency, serializer, bufferOptions, conf)
+
+  override def recordsWritten: Int = aggImpl.recordsWritten
+
+  // Fraction of the total records which were aggregated
+  override def reductionFactor: Double = {
+    if (recordsRead == 0) {
+      // Case of an empty partition
+      0.0
+    } else {
+      // Since the records in the map are already aggregated, total records post
+      // aggregation would be sum of records written to RSS servers so far (because of spill if any)
+      // and number of records in the map
+      val recordsCountPostAgg = recordsWritten + aggImpl.numberOfRecordsInMap
+      assert(recordsRead >= recordsCountPostAgg)
+      1.0 - (recordsCountPostAgg / recordsRead.toDouble)
+    }
+  }
+
+
+  override def addRecord(partitionId: Int, record: Product2[K, V]): Seq[(Int, Array[Byte])] = {
+    recordsRead += 1
+    aggImpl.addRecord(partitionId, record)
+  }
+
+  override def clear(): Seq[(Int, Array[Byte])] = {
+    aggImpl.spillMap()
+  }
+
+  override def collectionSizeInBytes: Int = {
+    aggImpl.collectionSizeInBytes
+  }
+}

--- a/src/main/scala/org/apache/spark/shuffle/rss/WriterNoAggregationManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/WriterNoAggregationManager.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.rss
+
+import org.apache.spark.ShuffleDependency
+import org.apache.spark.internal.Logging
+import org.apache.spark.serializer.Serializer
+
+/**
+ * For aggregation, using RDD APIs user can provide three functions -
+ * `creteCombiner` -> function to create an initial value for aggregation
+ *    (e.g. create an array list with just one value to start with)
+ * `mergeValue` -> function to merge new value into the prior aggregation result
+ *    (e.g. add value to the end of the array list if the key matches)
+ * `mergeCombiners` -> function to merge outputs of multiple mergeValue function
+ *    (e.g. combine two array list with matching keys)
+ *
+ * For a simple `reduceByKey(_ + _)` operation,
+ *  createCombiner would be,
+ *      def creteCombiner(value: V): V = value
+ *  mergeValue and mergeCombiner would be,
+ *      def mergeValue/mergeCombiners(oldValue: V, newValue: V): V = oldValue + newValue
+ *
+ * Only applies combiner function to each record and does not aggregate records. Reducer will aggregate
+ * these records while reading, [[org.apache.spark.shuffle.RssShuffleReader#read()]]
+ * This is logically equivalent of map side aggregation with reduction factor as 0.
+ */
+class WriterNoAggregationManager[K, V, C](shuffleDependency: ShuffleDependency[K, V, C],
+                                          serializer: Serializer,
+                                          bufferOptions: BufferManagerOptions)
+  extends WriteBufferManager[K, V, C](serializer, bufferOptions) with Logging {
+
+  private val createCombiner = shuffleDependency.aggregator.get.createCombiner
+
+  override def addRecord(partitionId: Int, record: Product2[K, V]): Seq[(Int, Array[Byte])] = {
+    val combinedValue = createCombiner(record._2)
+    addRecordImpl(partitionId, (record._1, combinedValue))
+  }
+}

--- a/src/test/scala/org/apache/spark/shuffle/ShuffleWithAggregationTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/ShuffleWithAggregationTest.scala
@@ -17,9 +17,16 @@ package org.apache.spark.shuffle
 import java.util.UUID
 
 import com.uber.rss.testutil.{RssMiniCluster, RssZookeeperCluster, StreamServerTestUtils}
-import org.apache.spark.{HashPartitioner, SparkContext}
+
+import org.apache.spark.rdd.RDD.rddToPairRDDFunctions
+import org.apache.spark.scheduler.{SparkListener, SparkListenerTaskEnd}
+import org.apache.spark.{SparkContext, TestUtils}
+
 import org.scalatest.Assertions._
 import org.testng.annotations._
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
 /***
  * This is to test shuffle with aggregation
@@ -28,11 +35,27 @@ class ShuffleWithAggregationTest {
 
   var appId: String = null
   val numRssServers = 2
-  
+
   var sc: SparkContext = null
-  
+
   var rssTestCluster: RssMiniCluster = null
-  
+
+  private def runAndReturnMetrics(job: => Unit,
+                                  collector: SparkListenerTaskEnd => Long): Long = {
+    val taskMetrics = new ArrayBuffer[Long]()
+
+    val listener = new SparkListener() {
+      override def onTaskEnd(taskEnd: SparkListenerTaskEnd) {
+        val metrics = collector(taskEnd)
+        taskMetrics.append(metrics)
+      }
+    }
+
+    TestUtils.withListener(sc, listener) {_ => job}
+
+    taskMetrics.sum
+  }
+
   @BeforeMethod
   def beforeTestMethod(): Unit = {
     appId = UUID.randomUUID().toString()
@@ -50,32 +73,311 @@ class ShuffleWithAggregationTest {
 
   @Test
   def foldByKey(): Unit = {
-    val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
+    Seq("true", "false").foreach(confValue => {
+      val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
+      conf.set("spark.shuffle.rss.mapSideAggregation.enabled", confValue)
+      sc = new SparkContext(conf)
 
+      val numValues = 1000
+      val numMaps = 3
+      val numPartitions = 5
+
+      val rdd = sc.parallelize(0 until numValues, numMaps)
+        .map(t=>((t/2) -> (t*2).longValue()))
+        .foldByKey(0, numPartitions)((v1, v2)=>v1 + v2)
+      val result = rdd.collect()
+
+      assert(sc.env.shuffleManager.getClass.getSimpleName === "RssShuffleManager")
+      assert(result.size === numValues/2)
+
+      for (i <- 0 until result.size) {
+        val key = result(i)._1
+        val value = result(i)._2
+        assert(key*2*2 + (key*2+1)*2 === value)
+      }
+
+      val keys = result.map(_._1).distinct.sorted
+      assert(keys.length === numValues/2)
+      assert(keys(0) === 0)
+      assert(keys.last === (numValues-1)/2)
+    })
+  }
+
+  /**
+   * There are two records for each key in the dataset. Those should be combined
+   * with map side aggregation or without map side aggregation (on reducer side).
+   */
+  @Test
+  def reduceByKey(): Unit = {
+    Seq("true", "false").foreach(confValue => {
+      val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
+      conf.set("spark.shuffle.rss.mapSideAggregation.enabled", confValue)
+      sc = new SparkContext(conf)
+
+      val numValues = 1000
+      val numMaps = 3
+      val numPartitions = 5
+
+      val rdd = sc.parallelize(0 until numValues, numMaps)
+        .map(t=>((t/2) -> (t*2).longValue()))
+        .reduceByKey(_ + _)
+      val result = rdd.collect()
+
+      assert(sc.env.shuffleManager.getClass.getSimpleName === "RssShuffleManager")
+      assert(result.size === numValues/2)
+
+      for (i <- 0 until result.size) {
+        val key = result(i)._1
+        val value = result(i)._2
+        assert(key*2*2 + (key*2+1)*2 === value)
+      }
+
+      val keys = result.map(_._1).distinct.sorted
+      assert(keys.length === numValues/2)
+      assert(keys(0) === 0)
+      assert(keys.last === (numValues-1)/2)
+    })
+  }
+
+  /**
+   * With map side aggregation disabled, there should be no reduction on mapper side, so number
+   * of written by mapper should be equal to number of records read.
+   */
+  @Test
+  def recordsNoAggregation(): Unit = {
+    val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
+    conf.set("spark.shuffle.rss.mapSideAggregation.enabled", "false")
+    conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
     sc = new SparkContext(conf)
 
     val numValues = 1000
-    val numMaps = 3
-    val numPartitions = 5
+    val numPartitions = 10
 
-    val rdd = sc.parallelize(0 until numValues, numMaps)
-      .map(t=>((t/2) -> (t*2).longValue()))
-      .foldByKey(0, numPartitions)((v1, v2)=>v1 + v2)
-    val result = rdd.collect()
+    val rdd = sc.parallelize(0 until numValues, numPartitions)
+      .map(t => ((t / 2) -> (t * 2).longValue()))
+      .reduceByKey(_ + _)
 
-    assert(sc.env.shuffleManager.getClass.getSimpleName === "RssShuffleManager")
-    assert(result.size === numValues/2)
-
-    for (i <- 0 until result.size) {
-      val key = result(i)._1
-      val value = result(i)._2
-      assert(key*2*2 + (key*2+1)*2 === value)
-    }
-
-    val keys = result.map(_._1).distinct.sorted
-    assert(keys.length === numValues/2)
-    assert(keys(0) === 0)
-    assert(keys.last === (numValues-1)/2)
+    val shuffleRecordsWritten = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleWriteMetrics.recordsWritten)
+    val shuffleRecordsRead = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleReadMetrics.recordsRead)
+    assert(shuffleRecordsWritten == 1000)
+    assert(shuffleRecordsRead == 1000)
   }
 
+  /**
+   * With map side aggregation enabled and low threshold memory allocated, map side aggregation would
+   * not be complete and only some of the record should get aggregated.
+   */
+  @Test
+  def recordsWrittenPartialAggregation(): Unit = {
+    val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
+    conf.set("spark.shuffle.rss.mapSideAggregation.enabled", "true")
+    conf.set("spark.shuffle.rss.mapSideAggregation.initialMemoryThresholdInBytes", "2000")
+    conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+    sc = new SparkContext(conf)
+
+    val numValues = 1000
+    val numPartitions = 10
+
+    val rdd = sc.parallelize(0 until numValues, numPartitions)
+      .map(t => ((t / 2) -> (t * 2).longValue()))
+      .mapPartitions(partition => {
+        partition.toSeq.sorted.iterator
+      })
+      .reduceByKey(_ + _)
+
+    val shuffleRecordsWritten = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleWriteMetrics.recordsWritten)
+    val shuffleRecordsRead = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleReadMetrics.recordsRead)
+    assert(shuffleRecordsWritten < 1000)
+    assert(shuffleRecordsRead < 1000)
+  }
+
+  /**
+   * With map side aggregation enabled and enough memory threshold to fit all the data in memory,
+   * map side aggregation should be complete.
+   */
+  @Test
+  def recordsWrittenCompleteAggregation(): Unit = {
+    val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
+    conf.set("spark.shuffle.rss.mapSideAggregation.enabled", "true")
+    conf.set("spark.shuffle.rss.mapSideAggregation.initialMemoryThresholdInBytes", "5242880")
+    conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+    sc = new SparkContext(conf)
+
+    val numValues = 1000
+    val numPartitions = 10
+
+    val rdd = sc.parallelize(0 until numValues, numPartitions)
+      .map(t => ((t / 2) -> (t * 2).longValue()))
+      .mapPartitions(partition => {
+        partition.toSeq.sorted.iterator
+      })
+      .reduceByKey(_ + _)
+
+    val shuffleRecordsWritten = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleWriteMetrics.recordsWritten)
+    val shuffleRecordsRead = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleReadMetrics.recordsRead)
+    assert(shuffleRecordsWritten == 500)
+    assert(shuffleRecordsRead == 500)
+  }
+
+  /**
+   * Each partition here would read 100 records. All the key values are the same, so with map side aggregation
+   * each mapper should only write 1 record, so 10 (1 * 10 partitions) records should be written in mapper stage.
+   */
+  @Test
+  def customAggregation(): Unit = {
+    Seq("true", "false").foreach(confValue => {
+      val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
+      conf.set("spark.shuffle.rss.mapSideAggregation.enabled", confValue)
+      conf.set("spark.shuffle.rss.mapSideAggregation.initialMemoryThresholdInBytes", "5242880")
+      conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+      sc = new SparkContext(conf)
+
+      val numValues = 1000
+      val numPartitions = 10
+
+      val list = List.fill(numValues)(0)
+
+      val rdd = sc.parallelize(list, numPartitions)
+        .map(t => t -> t.longValue)
+
+      val rddCombined = rdd.combineByKey(
+        (i: Long) => mutable.Set(i),
+        (set: mutable.Set[Long], i: Long) => set += i,
+        (set1: mutable.Set[Long], set2: mutable.Set[Long]) => set1 ++= set2)
+
+      val shuffleRecordsWritten = runAndReturnMetrics(rddCombined.collect(), _.taskMetrics.shuffleWriteMetrics.recordsWritten)
+      val shuffleRecordsRead = runAndReturnMetrics(rddCombined.collect(), _.taskMetrics.shuffleReadMetrics.recordsRead)
+
+      if (confValue == "true") {
+        // Since all keys are same, only one record should be written per partition
+        assert(shuffleRecordsWritten == 10)
+        assert(shuffleRecordsRead == 10)
+      } else {
+        assert(shuffleRecordsWritten == 1000)
+        assert(shuffleRecordsRead == 1000)
+      }
+    })
+  }
+
+  /**
+   * Test for case when all partitions are empty.
+   */
+  @Test
+  def aggregationNoRecords(): Unit = {
+    Seq("true", "false").foreach(confValue => {
+      val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
+      conf.set("spark.shuffle.rss.mapSideAggregation.enabled", confValue)
+      conf.set("spark.shuffle.rss.mapSideAggregation.initialMemoryThresholdInBytes", "5242880")
+      conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+      sc = new SparkContext(conf)
+
+      val numValues = 0
+      val numPartitions = 10
+
+      val rdd = sc.parallelize(0 until numValues, numPartitions)
+        .map(t => ((t / 2) -> (t * 2).longValue()))
+        .mapPartitions(partition => {
+          partition.toSeq.sorted.iterator
+        })
+        .reduceByKey(_ + _)
+
+      val shuffleRecordsWritten = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleWriteMetrics.recordsWritten)
+      val shuffleRecordsRead = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleReadMetrics.recordsRead)
+      assert(shuffleRecordsWritten == 0)
+      assert(shuffleRecordsRead == 0)
+    })
+  }
+
+  /**
+   * Test for case when only 1 partition has data and all others are empty.
+   */
+  @Test
+  def aggregationSingleRecordEmptyPartitions(): Unit = {
+    // Only one partition has data, rest all partitions are empty
+    Seq("true", "false").foreach(confValue => {
+      val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
+      conf.set("spark.shuffle.rss.mapSideAggregation.enabled", confValue)
+      conf.set("spark.shuffle.rss.mapSideAggregation.initialMemoryThresholdInBytes", "5242880")
+      conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+      sc = new SparkContext(conf)
+
+      val numValues = 1
+      val numPartitions = 10
+
+      val rdd = sc.parallelize(0 until numValues, numPartitions)
+        .map(t => ((t / 2) -> (t * 2).longValue()))
+        .mapPartitions(partition => {
+          partition.toSeq.sorted.iterator
+        })
+        .reduceByKey(_ + _)
+
+      val shuffleRecordsWritten = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleWriteMetrics.recordsWritten)
+      val shuffleRecordsRead = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleReadMetrics.recordsRead)
+      assert(shuffleRecordsWritten == 1)
+      assert(shuffleRecordsRead == 1)
+    })
+  }
+
+  /**
+   * Assign just enough memory that spill happens only once after all records are processed.
+   */
+  @Test
+  def aggregationJustEnoughMemory(): Unit = {
+    // Assign just enough memory that spill happens only once all records are processed
+    Seq("true", "false").foreach(confValue => {
+      val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
+      conf.set("spark.shuffle.rss.mapSideAggregation.enabled", confValue)
+      // Size for the 1 records gets estimated to be around 920
+      conf.set("spark.shuffle.rss.mapSideAggregation.initialMemoryThresholdInBytes", "921")
+      conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+      sc = new SparkContext(conf)
+
+      val numValues = 1
+      val numPartitions = 1
+
+      val rdd = sc.parallelize(0 until numValues, numPartitions)
+        .map(t => ((t / 2) -> (t * 2).longValue()))
+        .mapPartitions(partition => {
+          partition.toSeq.sorted.iterator
+        })
+        .reduceByKey(_ + _)
+
+      val shuffleRecordsWritten = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleWriteMetrics.recordsWritten)
+      val shuffleRecordsRead = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleReadMetrics.recordsRead)
+      assert(shuffleRecordsWritten == 1)
+      assert(shuffleRecordsRead == 1)
+    })
+  }
+
+  /**
+   * Assign just enough memory that spill happens before all records are processed.
+   */
+  @Test
+  def aggregationJustNotEnoughMemory(): Unit = {
+    // Assign just enough memory that spill happens just before last record is processed and
+    // and the last record has to be written to RSS as part of the post record processing spill
+    Seq("true", "false").foreach(confValue => {
+      val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
+      conf.set("spark.shuffle.rss.mapSideAggregation.enabled", confValue)
+      // Size for the 1 records gets estimated to be around 920
+      conf.set("spark.shuffle.rss.mapSideAggregation.initialMemoryThresholdInBytes", "920")
+      conf.set("spark.sql.autoBroadcastJoinThreshold", "-1")
+      sc = new SparkContext(conf)
+
+      val numValues = 2
+      val numPartitions = 1
+
+      val rdd = sc.parallelize(0 until numValues, numPartitions)
+        .map(t => ((t / 2) -> (t * 2).longValue()))
+        .mapPartitions(partition => {
+          partition.toSeq.sorted.iterator
+        })
+        .reduceByKey(_ + _)
+
+      val shuffleRecordsWritten = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleWriteMetrics.recordsWritten)
+      val shuffleRecordsRead = runAndReturnMetrics(rdd.collect(), _.taskMetrics.shuffleReadMetrics.recordsRead)
+      assert(shuffleRecordsWritten == 2)
+      assert(shuffleRecordsRead == 2)
+    })
+  }
 }


### PR DESCRIPTION
Does a best effort at doing a map side aggregation. A map of 10MB (configurable) per mapper can be used currently to do a map side aggregation. Post that data will be spilled (meaning sent to RSS servers). In such cases, map side aggregation will be partial and reducers will take care of aggregating such partially aggregated data.

 Following improvements will be taken up in a separate PR:
    1. Dynamically allocate memory to MapSide combine
    2. Add reduction factor based backoff in map side aggregation