### PR TITLE
Changing Zk connection creation in the RSS client. Zk Connections wer…

### DIFF
--- a/src/main/java/com/uber/rss/metrics/MetadataClientMetrics.java
+++ b/src/main/java/com/uber/rss/metrics/MetadataClientMetrics.java
@@ -15,6 +15,7 @@
 package com.uber.rss.metrics;
 
 import com.uber.m3.tally.Counter;
+import com.uber.m3.tally.Gauge;
 import com.uber.m3.tally.Scope;
 import com.uber.m3.tally.Timer;
 
@@ -26,13 +27,15 @@ public class MetadataClientMetrics extends MetricGroup<MetadataClientMetricsKey>
     private final Counter numRequests;
     private final Counter numFailures;
     private final Timer requestLatency;
-    
+    private final Gauge numConnections;
+
     public MetadataClientMetrics(MetadataClientMetricsKey key) {
         super(key);
 
         this.numRequests = scope.counter("numRequests");
         this.numFailures = scope.counter("numFailures");
         this.requestLatency = scope.timer("requestLatency");
+        this.numConnections = scope.gauge("numConnections");
     }
 
     public Counter getNumRequests() {
@@ -45,6 +48,10 @@ public class MetadataClientMetrics extends MetricGroup<MetadataClientMetricsKey>
 
     public Timer getRequestLatency() {
         return requestLatency;
+    }
+
+    public Gauge getNumConnections() {
+        return numConnections;
     }
 
     @Override

--- a/src/main/scala/org/apache/spark/shuffle/RssServiceRegistry.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssServiceRegistry.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle
+
+import com.uber.rss.exceptions.RssException
+import com.uber.rss.metadata.{ServiceRegistry, StandaloneServiceRegistryClient, ZooKeeperServiceRegistry}
+import com.uber.rss.util.ServerHostAndPort
+import com.uber.rss.StreamServerConfig
+import org.apache.commons.lang3.StringUtils
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.Logging
+
+object RssServiceRegistry extends Logging {
+  private[this] var sparkConfOpts: Option[SparkConf] = None
+
+  def init(conf: SparkConf): Unit = synchronized {
+    logInfo("Initializing RssServiceRegistry's SparkConf.")
+    sparkConfOpts = Some(conf)
+  }
+
+  def sparkConf: SparkConf = {
+    if(sparkConfOpts.isEmpty) {
+      logError("SparkConf not Initialized. Call 'RssServiceRegistry.init' before calling this method.")
+      throw new IllegalStateException("RssServiceRegistry object not Initialized.")
+    }
+    sparkConfOpts.get
+  }
+
+  private def getZooKeeperServers: String = {
+    val serversValue = sparkConf.get(RssOpts.serviceRegistryZKServers)
+    serversValue
+  }
+
+  def getDataCenter: String = {
+    var dataCenterValue = sparkConf.get(RssOpts.dataCenter)
+    if (StringUtils.isBlank(dataCenterValue)) {
+      dataCenterValue = StreamServerConfig.DEFAULT_DATA_CENTER;
+    }
+    dataCenterValue
+  }
+
+  private def createServiceRegistry: ServiceRegistry = {
+    val serviceRegistryType = sparkConf.get(RssOpts.serviceRegistryType)
+    val networkTimeoutMillis = sparkConf.get(RssOpts.networkTimeout).toInt
+    val networkRetries = sparkConf.get(RssOpts.networkRetries).toInt
+
+    logInfo(s"Service registry type: $serviceRegistryType")
+
+    serviceRegistryType match {
+      case ServiceRegistry.TYPE_ZOOKEEPER =>
+        val zkServers = getZooKeeperServers
+        ZooKeeperServiceRegistry.createTimingInstance(zkServers, networkTimeoutMillis, networkRetries)
+      case ServiceRegistry.TYPE_STANDALONE =>
+        val serviceRegistryServer = sparkConf.get(RssOpts.serviceRegistryServer)
+        if (StringUtils.isBlank(serviceRegistryServer)) {
+          throw new RssException(s"${RssOpts.serviceRegistryServer.key} configure is not set")
+        }
+        val hostAndPort = ServerHostAndPort.fromString(serviceRegistryServer)
+        new StandaloneServiceRegistryClient(hostAndPort.getHost, hostAndPort.getPort, networkTimeoutMillis, "rss")
+      case _ => throw new IllegalArgumentException(s"Invalid service registry type: $serviceRegistryType" )
+    }
+  }
+
+  def executeWithServiceRegistry[R](callback:(ServiceRegistry) => R): R = {
+    var serviceRegistry: Option[ServiceRegistry] = None
+    try {
+      serviceRegistry = Some(createServiceRegistry)
+      callback(serviceRegistry.get)
+    } finally {
+      if(serviceRegistry.isDefined) {
+        serviceRegistry.get.close()
+      }
+    }
+  }
+}

--- a/src/main/scala/org/apache/spark/shuffle/RssShuffleReader.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssShuffleReader.scala
@@ -15,7 +15,6 @@
 package org.apache.spark.shuffle
 
 import com.uber.rss.common.{AppShuffleId, ServerList}
-import com.uber.rss.metadata.ServiceRegistry
 import org.apache.spark.internal.Logging
 import org.apache.spark.serializer.Serializer
 import org.apache.spark.shuffle.rss.BlockDownloaderPartitionRangeRecordIterator
@@ -34,7 +33,6 @@ class RssShuffleReader[K, C](
                               numMaps: Int,
                               rssServers: ServerList,
                               partitionFanout: Int,
-                              serviceRegistry: ServiceRegistry,
                               serviceRegistryDataCenter: String,
                               serviceRegistryCluster: String,
                               timeoutMillis: Int,
@@ -60,7 +58,6 @@ class RssShuffleReader[K, C](
       numMaps = numMaps,
       rssServers = rssServers,
       partitionFanout = partitionFanout,
-      serviceRegistry = serviceRegistry,
       serviceRegistryDataCenter = serviceRegistryDataCenter,
       serviceRegistryCluster = serviceRegistryCluster,
       timeoutMillis = timeoutMillis,

--- a/src/main/scala/org/apache/spark/shuffle/rss/RssStressTool.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/RssStressTool.scala
@@ -24,7 +24,7 @@ import java.util.function.Consumer
 import com.uber.rss.clients._
 import com.uber.rss.common._
 import com.uber.rss.metadata.ServiceRegistry
-import com.uber.rss.metrics.{M3Stats, ShuffleClientStageMetrics, ShuffleClientStageMetricsKey}
+import com.uber.rss.metrics.{ShuffleClientStageMetrics, ShuffleClientStageMetricsKey}
 import com.uber.rss.storage.ShuffleFileStorage
 import com.uber.rss.{StreamServer, StreamServerConfig}
 import org.apache.commons.lang3.StringUtils
@@ -362,7 +362,6 @@ class RssStressTool extends Logging {
       numMaps = numMaps,
       rssServers = new ServerList(serverDetails),
       partitionFanout = 1,
-      serviceRegistry = registryServer.getServiceRegistry,
       serviceRegistryDataCenter = ServiceRegistry.DEFAULT_DATA_CENTER,
       serviceRegistryCluster = ServiceRegistry.DEFAULT_TEST_CLUSTER,
       timeoutMillis = 30000,


### PR DESCRIPTION
…e created from the RSS client at the start of drivers and executors, now we will create a Zk connection when required and close the connection eagerly. The change reduces Zk connection/FD count.