### PR TITLE
Adding server sequence registry for k8 rss servers

### DIFF
--- a/src/main/java/com/uber/rss/metadata/ServerSequenceServiceRegistry.java
+++ b/src/main/java/com/uber/rss/metadata/ServerSequenceServiceRegistry.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.rss.metadata;
+
+import com.uber.rss.common.ServerDetail;
+import com.uber.rss.common.ServerDetailCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/***
+ * This is in service registry for continuous server sequence.
+ */
+public class ServerSequenceServiceRegistry implements ServiceRegistry {
+    private static final String DEFAULT_CLUSTER = "default";
+
+    private static final Logger logger =
+            LoggerFactory.getLogger(ServerSequenceServiceRegistry.class);
+
+    private final String serverIdFormat; // String format for server ID: e.g. "rss-%s"
+    private final String connectionStringFormat;
+    // String format for connection string: e.g. "rss-%s.rss.remote-shuffle-service.svc.cluster.local:9338"
+    private final int sequenceStartIndex;
+    private final int sequenceEndIndex;
+
+    private final ServerDetailCollection serverCollection = new ServerDetailCollection();
+
+    public ServerSequenceServiceRegistry(String serverIdFormat, String connectionStringFormat,
+                                         int sequenceStartIndex, int sequenceEndIndex, String runningVersion) {
+        this.serverIdFormat = serverIdFormat;
+        this.connectionStringFormat = connectionStringFormat;
+        this.sequenceStartIndex = sequenceStartIndex;
+        this.sequenceEndIndex = sequenceEndIndex;
+
+        for (int i = sequenceStartIndex; i <= sequenceEndIndex; i++) {
+            String serverId = String.format(serverIdFormat, i);
+            ServerDetail serverDetail =
+                    new ServerDetail(serverId, runningVersion, String.format(connectionStringFormat, i));
+            serverCollection
+                    .addServer(DEFAULT_DATA_CENTER, DEFAULT_CLUSTER, serverDetail);
+        }
+
+        logger.info("Created " + this);
+    }
+
+    @Override
+    public synchronized void registerServer(String dataCenter, String cluster, String serverId,
+                                            String runningVersion, String hostAndPort) {
+        return;
+    }
+
+    @Override
+    public synchronized List<ServerDetail> getServers(String dataCenter, String cluster,
+                                                      int maxCount,
+                                                      Collection<String> excludeHosts) {
+        // we do not care about data center and cluster, thus set them to default values
+        dataCenter = DEFAULT_DATA_CENTER;
+        cluster = DEFAULT_CLUSTER;
+
+        List<ServerDetail> servers = serverCollection.getServers(dataCenter, cluster);
+
+        if (servers.size() <= maxCount) {
+            return new ArrayList<>(servers);
+        } else {
+            return servers.subList(0, maxCount);
+        }
+    }
+
+    @Override
+    public List<ServerDetail> lookupServers(String dataCenter, String cluster,
+                                            Collection<String> serverIds) {
+        // we do not care about data center and cluster, thus set them to default values
+        dataCenter = DEFAULT_DATA_CENTER;
+        cluster = DEFAULT_CLUSTER;
+        return serverCollection.lookupServers(dataCenter, cluster, serverIds);
+    }
+
+    @Override
+    public synchronized void close() {
+    }
+}

--- a/src/main/java/com/uber/rss/metadata/ServerSequenceServiceRegistry.java
+++ b/src/main/java/com/uber/rss/metadata/ServerSequenceServiceRegistry.java
@@ -53,7 +53,7 @@ public class ServerSequenceServiceRegistry implements ServiceRegistry {
                     .addServer(DEFAULT_DATA_CENTER, DEFAULT_CLUSTER, serverDetail);
         }
 
-        logger.info("Created " + this);
+        logger.info("Created " + this.toString());
     }
 
     @Override
@@ -90,5 +90,19 @@ public class ServerSequenceServiceRegistry implements ServiceRegistry {
 
     @Override
     public synchronized void close() {
+    }
+
+    @Override
+    public String toString() {
+        return String.format("" +
+                "serverIdFormat %s " +
+                "connectionStringFormat %s" +
+                "sequenceStartIndex %d" +
+                "sequenceEndIndex %d" +
+                "server Collection %s ",
+                this.serverIdFormat,
+                this.connectionStringFormat,
+                this.sequenceStartIndex,this.sequenceEndIndex,
+                this.serverCollection.toString());
     }
 }

--- a/src/test/java/com/uber/rss/metadata/ServerSequenceServiceRegistryTest.java
+++ b/src/test/java/com/uber/rss/metadata/ServerSequenceServiceRegistryTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.rss.metadata;
+
+import com.uber.rss.common.ServerDetail;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+public class ServerSequenceServiceRegistryTest {
+    @Test
+    public void oneServerSequence() {
+        ServerSequenceServiceRegistry serviceRegistry =
+                new ServerSequenceServiceRegistry("server-%s", "server-%s.domain", 0, 0,"1");
+
+        Assert.assertEquals(
+                serviceRegistry.getServers("dc1", "cluster1", 0, Collections.emptyList()).size(), 0);
+
+        List<ServerDetail> result =
+                serviceRegistry.getServers("dc1", "cluster1", Integer.MAX_VALUE, Collections.emptyList());
+        Assert.assertEquals(result.size(), 1);
+        Assert.assertEquals(result.get(0).getServerId(), "server-0");
+        Assert.assertEquals(result.get(0).getConnectionString(), "server-0.domain");
+
+        result = serviceRegistry.lookupServers("dc1", "cluster1", Arrays.asList("server-0"));
+        Assert.assertEquals(result.size(), 1);
+        Assert.assertEquals(result.get(0).getServerId(), "server-0");
+        Assert.assertEquals(result.get(0).getConnectionString(), "server-0.domain");
+    }
+
+    @Test
+    public void multiServerSequence() {
+        ServerSequenceServiceRegistry serviceRegistry =
+                new ServerSequenceServiceRegistry("server-%s", "server-%s.domain", 0, 2,"1");
+
+        Assert.assertEquals(
+                serviceRegistry.getServers("dc1", "cluster1", 0, Collections.emptyList()).size(), 0);
+
+        List<ServerDetail> result =
+                serviceRegistry.getServers("dc1", "cluster1", Integer.MAX_VALUE, Collections.emptyList());
+        result.sort(Comparator.comparing(ServerDetail::getServerId));
+        Assert.assertEquals(result.size(), 3);
+        Assert.assertEquals(result.get(0).getServerId(), "server-0");
+        Assert.assertEquals(result.get(0).getConnectionString(), "server-0.domain");
+        Assert.assertEquals(result.get(2).getServerId(), "server-2");
+        Assert.assertEquals(result.get(2).getConnectionString(), "server-2.domain");
+
+        result =
+                serviceRegistry.lookupServers("dc1", "cluster1", Arrays.asList("server-0", "server-2"));
+        result.sort(Comparator.comparing(ServerDetail::getServerId));
+        Assert.assertEquals(result.size(), 2);
+        Assert.assertEquals(result.get(0).getServerId(), "server-0");
+        Assert.assertEquals(result.get(0).getConnectionString(), "server-0.domain");
+        Assert.assertEquals(result.get(1).getServerId(), "server-2");
+        Assert.assertEquals(result.get(1).getConnectionString(), "server-2.domain");
+    }
+}


### PR DESCRIPTION
For Kubernetes, we have to create a service registry that can be used for the K8 stateful set. ZK is not always available for K8 in cloud so this metadata registry is for removing the dependency on the zk.
This service registry always create a set of servers in sequence.