### PR TITLE
RSS-K8: Adding the server sequence service registry to shuffle manager

### DIFF
--- a/src/main/java/com/uber/rss/metadata/ServiceRegistry.java
+++ b/src/main/java/com/uber/rss/metadata/ServiceRegistry.java
@@ -25,9 +25,10 @@ import com.uber.rss.common.ServerDetail;
  */
 public interface ServiceRegistry extends AutoCloseable {
 
-    String TYPE_ZOOKEEPER = "zookeeper";
-    String TYPE_INMEMORY = "inmemory";
-    String TYPE_STANDALONE = "standalone";
+    String TYPE_ZOOKEEPER       = "zookeeper";
+    String TYPE_INMEMORY        = "inmemory";
+    String TYPE_STANDALONE      = "standalone";
+    String TYPE_SERVER_SEQUENCE = "serverSequence";
     List<String> VALID_TYPES = Arrays.asList(
             TYPE_ZOOKEEPER,
             TYPE_INMEMORY,

--- a/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
@@ -152,7 +152,7 @@ object RssOpts {
       .createWithDefault(0)
   val serverSequenceEndIndex: ConfigEntry[Int] =
     ConfigBuilder("spark.shuffle.rss.serverSequence.endIndex")
-      .doc("Server sequence start index")
+      .doc("Server sequence end index")
       .intConf
       .createWithDefault(0)
 

--- a/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
@@ -14,7 +14,6 @@
 package org.apache.spark.shuffle
 
 import com.uber.rss.messages.MessageConstants
-import com.uber.rss.storage.ShuffleFileStorage
 import org.apache.spark.internal.config.{ConfigBuilder, ConfigEntry}
 
 object RssOpts {
@@ -35,12 +34,14 @@ object RssOpts {
       .createWithDefault(20)
   val writerQueueSize: ConfigEntry[Int] =
     ConfigBuilder("spark.shuffle.rss.writer.queueSize")
-      .doc("writer queue size for shuffle writer to store shuffle records and send them to shuffle server in background threads.")
+      .doc("writer queue size for shuffle writer to store shuffle records and send them to " +
+        "shuffle server in background threads.")
       .intConf
       .createWithDefault(0)
   val writerMaxThreads: ConfigEntry[Int] =
     ConfigBuilder("spark.shuffle.rss.writer.maxThreads")
-      .doc("max number of threads for shuffle writer to store shuffle records and send them to shuffle server in background threads.")
+      .doc("max number of threads for shuffle writer to store shuffle records and send them to" +
+        " shuffle server in background threads.")
       .intConf
       .createWithDefault(2)
   val writerAsyncFinish: ConfigEntry[Boolean] =
@@ -55,13 +56,15 @@ object RssOpts {
       .createWithDefault(MessageConstants.DEFAULT_SHUFFLE_DATA_MESSAGE_SIZE)
   val writerBufferMax: ConfigEntry[Int] =
     ConfigBuilder("spark.shuffle.rss.writer.bufferMax")
-      .doc("Internal buffer max limit for shuffle writer. The buffer could temporarily grow to this size if there " +
+      .doc("Internal buffer max limit for shuffle writer. The buffer could temporarily" +
+        " grow to this size if there " +
         "is a single large shuffle record to serialize into the buffer.")
       .intConf
       .createWithDefault(512 * 1024 * 1024)
   val writerBufferSpill: ConfigEntry[Int] =
     ConfigBuilder("spark.shuffle.rss.writer.bufferSpill")
-      .doc("The threshold for shuffle writer buffer to spill data. Here spill means removing the data out of the buffer " +
+      .doc("The threshold for shuffle writer buffer to spill data. " +
+        "Here spill means removing the data out of the buffer " +
         "and send to shuffle server.")
       .intConf
       .createWithDefault(32 * 1024 * 1024)
@@ -82,19 +85,21 @@ object RssOpts {
       .createWithDefault(5)
   val maxWaitTime: ConfigEntry[Long] =
     ConfigBuilder("spark.shuffle.rss.maxWaitTime")
-      .doc("maximum wait time (milliseconds) for shuffle client, e.g. retry connecting to busy remote shuffle server.")
+      .doc("maximum wait time (milliseconds) for shuffle client, e.g. retry connecting to " +
+        "busy remote shuffle server.")
       .longConf
-      .createWithDefault(3*60*1000L)
+      .createWithDefault(3 * 60 * 1000L)
   val pollInterval: ConfigEntry[Int] =
     ConfigBuilder("spark.shuffle.rss.pollInterval")
-      .doc("poll interval (milliseconds) to query remote shuffle server for status update, e.g. whether a map task's data flushed.")
+      .doc("poll interval (milliseconds) to query remote shuffle server for status update, " +
+        "e.g. whether a map task's data flushed.")
       .intConf
       .createWithDefault(200)
   val readerDataAvailableWaitTime: ConfigEntry[Long] =
     ConfigBuilder("spark.shuffle.rss.reader.dataAvailableWaitTime")
       .doc("max wait time in shuffle reader to wait data ready in the shuffle server.")
       .longConf
-      .createWithDefault(5*60*1000L)
+      .createWithDefault(5 * 60 * 1000L)
   val readerSorterBufferSize: ConfigEntry[String] =
     ConfigBuilder("spark.shuffle.rss.reader.sorterBufferSize")
       .doc("buffer size for the sorter used in shuffle reader")
@@ -107,7 +112,7 @@ object RssOpts {
       .createWithDefault(20 * 1024 * 1024)
   val dataCenter: ConfigEntry[String] =
     ConfigBuilder("spark.shuffle.rss.dataCenter")
-      .doc("data center for RSS cluster. If not specified, will try to get value from the environment.")
+      .doc("data center for RSS cluster.")
       .stringConf
       .createWithDefault("")
   val cluster: ConfigEntry[String] =
@@ -130,11 +135,32 @@ object RssOpts {
       .doc("Registry server host:port addresses.")
       .stringConf
       .createWithDefault("")
+  val serverSequenceServerId: ConfigEntry[String] =
+    ConfigBuilder("spark.shuffle.rss.serverSequence.serverId")
+      .doc("Server ID format for server sequence")
+      .stringConf
+      .createWithDefault("rss-%s")
+  val serverSequenceConnectionString: ConfigEntry[String] =
+    ConfigBuilder("spark.shuffle.rss.serverSequence.connectionString")
+      .doc("Connection string format for server sequence")
+      .stringConf
+      .createWithDefault("rss-%s.rss.remote-shuffle-service.svc.cluster.local:9338")
+  val serverSequenceStartIndex: ConfigEntry[Int] =
+    ConfigBuilder("spark.shuffle.rss.serverSequence.startIndex")
+      .doc("Server sequence start index")
+      .intConf
+      .createWithDefault(0)
+  val serverSequenceEndIndex: ConfigEntry[Int] =
+    ConfigBuilder("spark.shuffle.rss.serverSequence.endIndex")
+      .doc("Server sequence start index")
+      .intConf
+      .createWithDefault(0)
+
   val minSplits: ConfigEntry[Int] =
-  ConfigBuilder("spark.shuffle.rss.minSplits")
-    .doc("min number of splits for each shuffle partition on each shuffle server.")
-    .intConf
-    .createWithDefault(1)
+    ConfigBuilder("spark.shuffle.rss.minSplits")
+      .doc("min number of splits for each shuffle partition on each shuffle server.")
+      .intConf
+      .createWithDefault(1)
   val maxSplits: ConfigEntry[Int] =
     ConfigBuilder("spark.shuffle.rss.maxSplits")
       .doc("max number of splits for each shuffle partition on each shuffle server.")
@@ -154,7 +180,8 @@ object RssOpts {
       .createWithDefault(1)
   val checkReplicaConsistency: ConfigEntry[Boolean] =
     ConfigBuilder("spark.shuffle.rss.checkReplicaConsistency")
-      .doc("Check replica data consistency when reading replicas. If set to true, it will consume more memory to track the data in client side.")
+      .doc("Check replica data consistency when reading replicas. If set to true, " +
+        "it will consume more memory to track the data in client side.")
       .booleanConf
       .createWithDefault(false)
   val excludeHosts: ConfigEntry[String] =

--- a/src/test/scala/org/apache/spark/shuffle/RssOptsTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/RssOptsTest.scala
@@ -23,7 +23,7 @@ class RssOptsTest {
   private val conf = new SparkConf()
 
   def testDefaultValues(): Unit = {
-    assert(conf.get(RssOpts.dataCenter) === "")
+    assert(conf.get(RssOpts.dataCenter) === "dataCenter1")
   }
 
 }

--- a/src/test/scala/org/apache/spark/shuffle/RssShuffleManagerTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/RssShuffleManagerTest.scala
@@ -135,7 +135,8 @@ class RssShuffleManagerTest {
   @Test(expectedExceptions = Array(classOf[RssException]))
   def excludeHosts(): Unit = {
     val conf = TestUtil.newSparkConfWithZooKeeperRegistryServer(appId, rssTestCluster.getZooKeeperServers)
-    conf.set("spark.shuffle.rss.excludeHosts", s"localhost,${NetworkUtils.getLocalHostName},${NetworkUtils.getLocalFQDN}")
+    conf.set("spark.shuffle.rss.excludeHosts",
+      s"localhost,${NetworkUtils.getLocalHostName},${NetworkUtils.getLocalFQDN}")
 
     sc = new SparkContext(conf)
 
@@ -166,7 +167,7 @@ class RssShuffleManagerTest {
     val numPartitions = 5
 
     val rdd = sc.parallelize(1 to 100)
-      .map(t=>(t->t*2))
+      .map(t => (t -> t * 2))
       .partitionBy(new HashPartitioner(numPartitions))
     val shuffleDependency = new ShuffleDependency[Int, Int, Int](rdd, rdd.partitioner.get)
 
@@ -183,8 +184,10 @@ class RssShuffleManagerTest {
     val mapStatus = (0 until numMaps).toList.par.map(mapId => {
       val taskAttemptId = mapId + 1000
       val mapTaskContext = new MockTaskContext(shuffleId, mapId, taskAttemptId)
-      val shuffleWriter = executorShuffleManager.getWriter[Int, Int]( shuffleHandle, mapId, mapTaskContext, new ShuffleWriteMetrics() )
-      val records = (1 to numValuesInMap).map(t => (mapId*1000+t) -> (mapId*1000+t*2)).iterator
+      val shuffleWriter = executorShuffleManager.
+        getWriter[Int, Int](
+          shuffleHandle, mapId, mapTaskContext, new ShuffleWriteMetrics() )
+      val records = (1 to numValuesInMap).map(t => (mapId * 1000 + t) -> (mapId * 1000 + t * 2)).iterator
       shuffleWriter.write(records)
       val mapStatus = shuffleWriter.stop(true).get
 
@@ -197,7 +200,13 @@ class RssShuffleManagerTest {
       val startPartition = 0
       val endPartition = 0
       val reduceTaskContext = new MockTaskContext( shuffleId, startPartition )
-      val shuffleReader = executorShuffleManager.getReader( shuffleHandle, startPartition, endPartition, reduceTaskContext, new TempShuffleReadMetrics() )
+      val shuffleReader = executorShuffleManager.
+        getReader(
+          shuffleHandle,
+          startPartition,
+          endPartition,
+          reduceTaskContext,
+          new TempShuffleReadMetrics() )
       val readRecords = shuffleReader.read().toList
       assert( readRecords.size === numMaps * numValuesInMap / numPartitions )
     }
@@ -205,7 +214,13 @@ class RssShuffleManagerTest {
       val startPartition = 0
       val endPartition = 1
       val reduceTaskContext = new MockTaskContext( shuffleId, startPartition )
-      val shuffleReader = executorShuffleManager.getReader( shuffleHandle, startPartition, endPartition, reduceTaskContext, new TempShuffleReadMetrics() )
+      val shuffleReader = executorShuffleManager.
+        getReader(
+          shuffleHandle,
+          startPartition,
+          endPartition,
+          reduceTaskContext,
+          new TempShuffleReadMetrics() )
       val readRecords = shuffleReader.read().toList
       assert( readRecords.size === numMaps * numValuesInMap / numPartitions )
     }
@@ -213,9 +228,15 @@ class RssShuffleManagerTest {
       val startPartition = 0
       val endPartition = 2
       val reduceTaskContext = new MockTaskContext( shuffleId, startPartition )
-      val shuffleReader = executorShuffleManager.getReader( shuffleHandle, startPartition, endPartition, reduceTaskContext, new TempShuffleReadMetrics() )
+      val shuffleReader = executorShuffleManager.
+        getReader(
+          shuffleHandle,
+          startPartition,
+          endPartition,
+          reduceTaskContext,
+          new TempShuffleReadMetrics() )
       val readRecords = shuffleReader.read().toList
-      assert( readRecords.size === 2 * numMaps * numValuesInMap / numPartitions )
+      assert(readRecords.size === 2 * numMaps * numValuesInMap / numPartitions)
     }
   }
 
@@ -232,7 +253,7 @@ class RssShuffleManagerTest {
     val partitionId = 0
 
     val rdd = sc.parallelize(1 to 100)
-      .map(t=>(t->t*2))
+      .map(t=> ( t ->t * 2))
       .partitionBy(new HashPartitioner(numPartitions))
     val shuffleDependency = new ShuffleDependency[Int, Int, Int](rdd, rdd.partitioner.get)
 
@@ -247,16 +268,22 @@ class RssShuffleManagerTest {
     shuffleManagers :+= executorShuffleManager
 
     val mapTaskContext = new MockTaskContext(shuffleId, mapId)
-    val shuffleWriter = executorShuffleManager.getWriter[String, String]( shuffleHandle, mapId, mapTaskContext, new ShuffleWriteMetrics() )
+    val shuffleWriter = executorShuffleManager.
+      getWriter[String, String]( shuffleHandle, mapId, mapTaskContext, new ShuffleWriteMetrics() )
     val records = List((null, ""), ("", null), (null, null))
     shuffleWriter.write(records.iterator)
     val mapStatus = shuffleWriter.stop(true).get
     mapOutputTrackerMaster.registerMapOutput(shuffleId, mapId, mapStatus)
 
     val reduceTaskContext = new MockTaskContext( shuffleId, partitionId )
-    val shuffleReader = executorShuffleManager.getReader( shuffleHandle, partitionId, partitionId, reduceTaskContext, new TempShuffleReadMetrics() )
+    val shuffleReader = executorShuffleManager.
+      getReader( shuffleHandle,
+                  partitionId,
+                  partitionId,
+                  reduceTaskContext,
+                  new TempShuffleReadMetrics() )
     val readRecords = shuffleReader.read().toList
-    assert( readRecords.size === 3 )
-    assert( readRecords === records )
+    assert(readRecords.size === 3)
+    assert(readRecords === records)
   }
 }


### PR DESCRIPTION
We have added the new server sequence service registry into the metadata 
In this pull request, we are adding the server sequence service registry to the shuffle manager  
This will let the client use the new registry service in the K8 environment