### PR TITLE
Fixed misleading error messages

### DIFF
--- a/src/main/java/com/uber/rss/metadata/ZooKeeperServiceRegistry.java
+++ b/src/main/java/com/uber/rss/metadata/ZooKeeperServiceRegistry.java
@@ -218,7 +218,7 @@ public class ZooKeeperServiceRegistry implements ServiceRegistry {
             bytes = zk.getData().forPath(nodePath);
         } catch (Exception e) {
             M3Stats.addException(e, this.getClass().getSimpleName());
-            throw new RssException(String.format("Failed to get node data for zookeeper node: %s", nodePath), e);
+            throw new RssException(String.format("Failed to get RSS node data from zookeeper %s", nodePath), e);
         }
 
         if (bytes == null) {

--- a/src/main/scala/org/apache/spark/shuffle/RssShuffleWriter.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssShuffleWriter.scala
@@ -79,7 +79,8 @@ class RssShuffleWriter[K, V, C](
   }
 
   override def write(records: Iterator[Product2[K, V]]): Unit = {
-    logInfo(s"Writing shuffle records ($mapInfo), map side combine: ${shuffleDependency.mapSideCombine}")
+    logInfo(s"Started processing records in Shuffle Map Task ($mapInfo), " +
+      s"map side combine: ${shuffleDependency.mapSideCombine}")
 
     var numRecords = 0
 


### PR DESCRIPTION
`com.uber.rss.exceptions.RssException: Failed to get node data for zookeeper node: /spark_rss/phx3/default/nodes/agent-dedicated1257-phx3.prod.uber.internal`

The current error message is misleading as it echoes that there are failure on the ZK end. Even though that could be the reason, these error are mainly causes by bad/lost RSS server node.

Also at the start of the map task, message points that task has started writing records which is not accurate. Fixing it to Started processing records in Shuffle Map Task