### PR TITLE
Create lazy connections to RSS servers from mappers

### DIFF
--- a/src/main/java/com/uber/rss/clients/LazyWriteClient.java
+++ b/src/main/java/com/uber/rss/clients/LazyWriteClient.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2020 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.rss.clients;
+
+import com.uber.rss.common.AppTaskAttemptId;
+import com.uber.rss.util.RetryUtils;
+import org.apache.spark.shuffle.RssOpts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.function.Supplier;
+
+/**
+ * Connections have a idle timeout of
+ * [[com.uber.rss.StreamServerConfig#DEFAULT_SERVER_SIDE_CONNECTION_IDLE_TIMEOUT_MILLIS]], so
+ * if the connections are established at the start of map task and downstream operations in a stage
+ * take a long time, these connections get timed out by the time mapper starts writing shuffle data.
+ *
+ * LazyWriteClient connects to the RSS servers just before the first batch of the data needs
+ * to be sent to ensure that such timeouts do not happen.
+ */
+public final class LazyWriteClient implements MultiServerWriteClient {
+
+    private final MultiServerWriteClient writeClient;
+    private final AppTaskAttemptId mapInfo;
+    private final int numMaps;
+    private final int numPartitions;
+    private final int pollInterval;
+    private final long maxWaitMillis;
+
+    private boolean connectedToWriteClient = false;
+
+    private static final Logger logger =
+            LoggerFactory.getLogger(HeartbeatSocketClient.class);
+
+    public LazyWriteClient(MultiServerWriteClient writeClient, AppTaskAttemptId mapInfo,
+                           int numMaps, int numPartitions, int pollInterval, long maxWaitMillis) {
+        this.writeClient = writeClient;
+        this.mapInfo = mapInfo;
+        this.numMaps = numMaps;
+        this.numPartitions = numPartitions;
+        this.pollInterval = pollInterval;
+        this.maxWaitMillis = maxWaitMillis;
+        logger.info("Using lazy write client to connect to RSS servers");
+    }
+
+
+    /**
+     * Without the LazyWriteClient, connection to clients is established at the very start of the mapper
+     * task by calling RssShuffleManager.getWriter::writeClient.connect(). When writeClient in RssShuffleManager
+     * is of type LazyWriteClient, this will be a no-op.
+     *
+     * RssShuffleWriter calls writeClient.writeDataBlock() for sending the shuffle data. So below in
+     * LazyClient.writeDataBlock(), connection will be established if not already done by calling
+     * lazyConnect() and laxyStartUpload().
+     */
+    @Override
+    public void connect() {}
+
+    @Override
+    public void startUpload(AppTaskAttemptId appTaskAttemptId, int numMaps, int numPartitions) {}
+
+    private void lazyStartUpload() {
+        writeClient.startUpload(this.mapInfo, this.numMaps, this.numPartitions);
+    }
+
+    /**
+     * There are retries in RssShuffleManager.getWriter() in case the chosen RSS server is not reachable.
+     * These retries are not applicable for LazyWriteClient since the connection is established just before sending
+     * first batch of the data. So we add similar retries here while establishing connection to RSS servers.
+     */
+    private void lazyConnect() {
+        RetryUtils.retry(pollInterval, pollInterval * 10, maxWaitMillis, "create write client", () -> {
+            writeClient.connect();
+            return 0;
+        });
+    }
+
+    @Override
+    public void writeDataBlock(int partition, ByteBuffer value) {
+        if (!connectedToWriteClient) {
+            lazyConnect();
+            lazyStartUpload();
+            connectedToWriteClient = true;
+        }
+        writeClient.writeDataBlock(partition, value);
+    }
+
+    @Override
+    public void finishUpload() {
+        // Current design requires a finish acknowledgment to be sent to RSS servers even if the partitions are empty.
+        // if the acknowledgment is not sent, reducer keeps waiting for shuffle data to be available and
+        // then eventually fails.
+
+        // TODO: Fix this behaviour. Empty partition is a pretty common occurrence. May be we can pass
+        //  the empty partition information in dummy map status and reducer can ignore the empty partitions
+        //  based on that.
+        if (!connectedToWriteClient) {
+            lazyConnect();
+            lazyStartUpload();
+            connectedToWriteClient = true;
+        }
+        writeClient.finishUpload();
+    }
+
+    @Override
+    public long getShuffleWriteBytes() {
+        return writeClient.getShuffleWriteBytes();
+    }
+
+    @Override
+    public void close() {
+        if (connectedToWriteClient) {
+            writeClient.close();
+        }
+    }
+}

--- a/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
@@ -172,4 +172,9 @@ object RssOpts {
       .doc("Initial memory to allocate each mapper for performing map side aggregation")
       .longConf
       .createWithDefault(5 * 1024 * 1024L)
+  val enableLazyMapperClientConnection: ConfigEntry[Boolean] =
+    ConfigBuilder("spark.shuffle.rss.server.createLazyMapperClientConnection")
+      .doc("Create lazy connections from mappers to RSS servers just before sending the shuffle data")
+      .booleanConf
+      .createWithDefault(true)
 }

--- a/src/main/scala/org/apache/spark/shuffle/rss/RssStressTool.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/RssStressTool.scala
@@ -20,7 +20,6 @@ import java.util.Random
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import java.util.function.Consumer
-
 import com.uber.rss.clients._
 import com.uber.rss.common._
 import com.uber.rss.metadata.ServiceRegistry
@@ -28,7 +27,7 @@ import com.uber.rss.metrics.{ShuffleClientStageMetrics, ShuffleClientStageMetric
 import com.uber.rss.storage.ShuffleFileStorage
 import com.uber.rss.{StreamServer, StreamServerConfig}
 import org.apache.commons.lang3.StringUtils
-import org.apache.spark.executor.ShuffleWriteMetrics
+import org.apache.spark.executor.{ShuffleWriteMetrics, TaskMetrics}
 import org.apache.spark.internal.Logging
 import org.apache.spark.serializer.KryoSerializer
 import org.apache.spark.shuffle.{MockTaskContext, RssOpts, RssShuffleReader, RssShuffleWriter}
@@ -327,7 +326,7 @@ class RssStressTool extends Logging {
       bufferOptions = BufferManagerOptions(writerBufferSize, 256 * 1024 * 1024, writerBufferSpill),
       shuffleDependency = shuffleDependency,
       stageMetrics = new ShuffleClientStageMetrics(new ShuffleClientStageMetricsKey("user1", "queue=1")),
-      shuffleWriteMetrics = new ShuffleWriteMetrics(),
+      taskMetrics = new TaskMetrics(),
       conf = sparkConf
     )
 

--- a/src/test/java/com/uber/rss/testutil/RssMiniCluster.java
+++ b/src/test/java/com/uber/rss/testutil/RssMiniCluster.java
@@ -33,6 +33,7 @@ public class RssMiniCluster {
     private List<String> streamServerRootDirs = new ArrayList<>();
     private String cluster;
     private List<StreamServer> streamServers = new ArrayList<>();
+    private StreamServerConfig streamServerConfig = new StreamServerConfig();
 
     public RssMiniCluster(int numRssServers, String cluster) {
         List<String> rootDirs = StreamServerTestUtils.createTempDirectories(numRssServers);
@@ -40,6 +41,11 @@ public class RssMiniCluster {
     }
 
     public RssMiniCluster(Collection<String> rootDirs, String cluster) {
+        construct(rootDirs, cluster);
+    }
+
+    public RssMiniCluster(Collection<String> rootDirs, String cluster, StreamServerConfig streamServerConfig) {
+        this.streamServerConfig = streamServerConfig;
         construct(rootDirs, cluster);
     }
 
@@ -77,6 +83,7 @@ public class RssMiniCluster {
         // Start first RSS server which acts as registry server as well
         try {
             StreamServerConfig streamServerConfig = new StreamServerConfig();
+            streamServerConfig.setIdleTimeoutMillis(this.streamServerConfig.getIdleTimeoutMillis());
             streamServerConfig.setServiceRegistryType(ServiceRegistry.TYPE_STANDALONE);
             streamServerConfig.setDataCenter(ServiceRegistry.DEFAULT_DATA_CENTER);
             streamServerConfig.setCluster(cluster);
@@ -98,6 +105,7 @@ public class RssMiniCluster {
             String rootDir = streamServerRootDirs.get(i);
             try {
                 StreamServerConfig streamServerConfig = new StreamServerConfig();
+                streamServerConfig.setIdleTimeoutMillis(this.streamServerConfig.getIdleTimeoutMillis());
                 streamServerConfig.setServiceRegistryType(ServiceRegistry.TYPE_STANDALONE);
                 streamServerConfig.setRegistryServer(registryServer);
                 streamServerConfig.setDataCenter(ServiceRegistry.DEFAULT_DATA_CENTER);

--- a/src/test/scala/org/apache/spark/shuffle/EmptyPartitionShuffleTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/EmptyPartitionShuffleTest.scala
@@ -17,6 +17,7 @@ package org.apache.spark.shuffle
 import java.util.UUID
 
 import com.uber.rss.testutil.{RssMiniCluster, RssZookeeperCluster}
+
 import org.apache.spark.{HashPartitioner, MapOutputTrackerMaster, ShuffleDependency, SparkConf, SparkContext, SparkEnv}
 import org.scalatest.Assertions._
 import org.testng.annotations._

--- a/src/test/scala/org/apache/spark/shuffle/LazyWriteClientTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/LazyWriteClientTest.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle
+
+import com.uber.rss.testutil.{RssMiniCluster, StreamServerTestUtils}
+import com.uber.rss.StreamServerConfig
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.SparkSession
+import org.scalatest.Assertions._
+import org.testng.annotations._
+
+import java.util.UUID
+
+class LazyWriteClientTest {
+
+  var appId: String = null
+  val numRssServers = 2
+
+  var sc: SparkContext = null
+
+  var rssTestCluster: RssMiniCluster = null
+
+  @BeforeMethod
+  def beforeTestMethod(): Unit = {
+    appId = UUID.randomUUID().toString()
+    val rootDirs = StreamServerTestUtils.createTempDirectories(numRssServers)
+    val streamServerConfig = new StreamServerConfig()
+    //    streamServerConfig.setIdleTimeoutMillis(100);
+    rssTestCluster = new RssMiniCluster(rootDirs, appId, streamServerConfig)
+  }
+
+  @AfterMethod
+  def afterTestMethod(): Unit = {
+    sc.stop()
+    rssTestCluster.stop()
+  }
+
+  /**
+   * Connection time out is set to 100 milli seconds. A timeout of 200 milliseconds is deliberately
+   * added in mapper task so that application should fail if the connection was established at the
+   * start of the mapper task instead of just before sending the shuffle data.
+   */
+  @Test
+  def testLazyClient(): Unit = {
+    Seq("false", "true").foreach(confValue => {
+      val conf = TestUtil.newSparkConfWithStandAloneRegistryServer(appId, rssTestCluster.getRegistryServerConnection)
+      conf.set("spark.shuffle.rss.server.createLazyMapperClientConnection", confValue)
+      sc = new SparkContext(conf)
+
+      val rdd = sc.parallelize(0 until 10, 1)
+        .mapPartitions(partition => {
+          Thread.sleep(200)
+          partition
+        })
+        .repartition(2)
+
+      if (confValue == "false") {
+        val thrown = intercept[Exception] {
+          rdd.collect()
+        }
+        assert(thrown.getCause.toString.matches("com.uber.rss.exceptions.RssNetworkException: " +
+          "writeMessageLengthAndContent failed.*Broken pipe.*"))
+      } else {
+        val resultSize = rdd.count()
+        assert(resultSize == 10)
+      }
+    })
+  }
+}

--- a/src/test/scala/org/apache/spark/shuffle/LazyWriteClientTest.scala
+++ b/src/test/scala/org/apache/spark/shuffle/LazyWriteClientTest.scala
@@ -37,7 +37,7 @@ class LazyWriteClientTest {
     appId = UUID.randomUUID().toString()
     val rootDirs = StreamServerTestUtils.createTempDirectories(numRssServers)
     val streamServerConfig = new StreamServerConfig()
-    //    streamServerConfig.setIdleTimeoutMillis(100);
+    streamServerConfig.setIdleTimeoutMillis(100)
     rssTestCluster = new RssMiniCluster(rootDirs, appId, streamServerConfig)
   }
 


### PR DESCRIPTION
Currently, there is a 2 hr connection timeout for connection between RSS clients and servers. The connections from mapper clients are established at the very start of the mapper task. So if the underneath operators (scan and any other operators on top) takes more than 2 hrs to complete, the connections gets broken by the time mapper task actually starts writing shuffle data.

This does not always cause failures as on retries, sometime the tasks do succeed. But nonetheless, this does add to a latency especially because high runtime tasks are failing because of this issue.

Keeping the flag enabled by default as this should be behaviour in all cases. We will remove the gated code once the fix is stable.