### PR TITLE
Optimize memory usage and reduce GC by eliminating memory copies

### DIFF
--- a/src/main/java/com/uber/rss/common/DataBlockHeader.java
+++ b/src/main/java/com/uber/rss/common/DataBlockHeader.java
@@ -19,6 +19,9 @@ package com.uber.rss.common;
 
 import com.uber.rss.util.ByteBufUtils;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+
 public class DataBlockHeader {
   public static int NUM_BYTES = Long.BYTES + Integer.BYTES;
 
@@ -27,6 +30,13 @@ public class DataBlockHeader {
     System.arraycopy(taskAttemptIdBytes, 0, bytes, 0, Long.BYTES);
     ByteBufUtils.writeInt(bytes, Long.BYTES, length);
     return bytes;
+  }
+
+  public static ByteBuf serializeToBuf(byte[] taskAttemptIdBytes, int length) {
+    ByteBuf buffer = ByteBufAllocator.DEFAULT.buffer(NUM_BYTES);
+    buffer.writeBytes(taskAttemptIdBytes);
+    buffer.writeInt(length);
+    return buffer;
   }
 
   public static DataBlockHeader deserializeFromBytes(byte[] bytes) {
@@ -53,9 +63,6 @@ public class DataBlockHeader {
 
   @Override
   public String toString() {
-    return "DataBlockHeader{" +
-        "taskAttemptId=" + taskAttemptId +
-        ", length=" + length +
-        '}';
+    return "DataBlockHeader{" + "taskAttemptId=" + taskAttemptId + ", length=" + length + '}';
   }
 }

--- a/src/main/java/com/uber/rss/execution/ShufflePartitionWriter.java
+++ b/src/main/java/com/uber/rss/execution/ShufflePartitionWriter.java
@@ -15,6 +15,16 @@
 
 package com.uber.rss.execution;
 
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.uber.m3.tally.Counter;
 import com.uber.m3.tally.Gauge;
 import com.uber.rss.common.AppShufflePartitionId;
@@ -22,17 +32,8 @@ import com.uber.rss.common.FilePathAndLength;
 import com.uber.rss.metrics.M3Stats;
 import com.uber.rss.storage.ShuffleOutputStream;
 import com.uber.rss.storage.ShuffleStorage;
-import com.uber.rss.util.ByteBufUtils;
-import io.netty.buffer.ByteBuf;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
+import io.netty.buffer.ByteBuf;
 
 /***
  * This class wraps logic to write for a single shuffle output file.
@@ -101,11 +102,8 @@ public class ShufflePartitionWriter {
       int outputStreamIndex = (int) (taskAttemptId % outputStreams.length);
       ShuffleOutputStream outputStream = outputStreams[outputStreamIndex];
 
-      int writtenBytes = bytes.readableBytes();
-      byte[] byteArray = ByteBufUtils.readBytes(bytes);
-
       isDirty = true;
-      outputStream.write(byteArray);
+      int writtenBytes = outputStream.write(bytes);
 
       streamPersistedBytesSnapshots
           .put(outputStream.getLocation(), outputStream.getWrittenBytes());

--- a/src/main/java/com/uber/rss/handlers/UploadServerHandler.java
+++ b/src/main/java/com/uber/rss/handlers/UploadServerHandler.java
@@ -109,7 +109,7 @@ public class UploadServerHandler {
     executor.writeData(new com.uber.rss.execution.ShuffleDataWrapper(
         appShuffleId, shuffleDataWrapper.getTaskAttemptId(),
         shuffleDataWrapper.getPartitionId(),
-        Unpooled.wrappedBuffer(shuffleDataWrapper.getBytes())));
+        shuffleDataWrapper.getBytes()));
   }
 
   public void finishUpload(long taskAttemptId) {

--- a/src/main/java/com/uber/rss/messages/ShuffleDataWrapper.java
+++ b/src/main/java/com/uber/rss/messages/ShuffleDataWrapper.java
@@ -15,6 +15,8 @@
 
 package com.uber.rss.messages;
 
+import io.netty.buffer.ByteBuf;
+
 /***
  * This class wraps a chunk of data inside the shuffle file. The data (bytes) should
  * be written to shuffle file directly.
@@ -22,9 +24,9 @@ package com.uber.rss.messages;
 public class ShuffleDataWrapper {
   private final int partitionId;
   private final long taskAttemptId;
-  private final byte[] bytes;
+  private final ByteBuf bytes;
 
-  public ShuffleDataWrapper(int partitionId, long taskAttemptId, byte[] bytes) {
+  public ShuffleDataWrapper(int partitionId, long taskAttemptId, ByteBuf bytes) {
     if (bytes == null) {
       throw new NullPointerException("bytes");
     }
@@ -42,7 +44,7 @@ public class ShuffleDataWrapper {
     return taskAttemptId;
   }
 
-  public byte[] getBytes() {
+  public ByteBuf getBytes() {
     return bytes;
   }
 
@@ -51,7 +53,7 @@ public class ShuffleDataWrapper {
     return "ShuffleDataWrapper{" +
         "partitionId=" + partitionId +
         ", taskAttemptId=" + taskAttemptId +
-        ", bytes.length=" + bytes.length +
+        ", bytes.length=" + bytes.readableBytes() +
         '}';
   }
 }

--- a/src/main/java/com/uber/rss/storage/ShuffleFileStorage.java
+++ b/src/main/java/com/uber/rss/storage/ShuffleFileStorage.java
@@ -97,7 +97,7 @@ public class ShuffleFileStorage implements ShuffleStorage {
   @Override
   public ShuffleOutputStream createWriterStream(String path, String compressionCodec) {
     // TODO remove compressionCodec from storage API
-    return new ShuffleFileOutputStream(new File(path));
+    return new ShuffleFileChannelOutputStream(new File(path));
   }
 
   @Override

--- a/src/main/java/com/uber/rss/storage/ShuffleOutputStream.java
+++ b/src/main/java/com/uber/rss/storage/ShuffleOutputStream.java
@@ -17,6 +17,8 @@
 
 package com.uber.rss.storage;
 
+import io.netty.buffer.ByteBuf;
+
 /***
  * Shuffle output stream interface.
  */
@@ -25,7 +27,7 @@ public interface ShuffleOutputStream extends AutoCloseable {
    * Write data to the stream.
    * @param bytes
    */
-  void write(byte[] bytes);
+  int write(ByteBuf bytes);
 
 
   /***

--- a/src/main/java/com/uber/rss/tools/StreamServerStressToolLongRun.java
+++ b/src/main/java/com/uber/rss/tools/StreamServerStressToolLongRun.java
@@ -121,6 +121,8 @@ public class StreamServerStressToolLongRun {
         System.exit(-1);
       }
     });
+    
+    long ts = System.currentTimeMillis();
 
     StreamServerStressToolLongRun longRun = new StreamServerStressToolLongRun();
 
@@ -158,6 +160,9 @@ public class StreamServerStressToolLongRun {
 
     M3Stats.closeDefaultScope();
 
+    ts = System.currentTimeMillis() - ts;
+    System.out.println("TS:" + ts / 1000);
+    
     logger.info(String.format("%s finished", StreamServerStressToolLongRun.class.getSimpleName()));
   }
 }


### PR DESCRIPTION
The current shuffle service implementation creates multiple copies of the shuffle write which leads to increased GC and under heavy load reduced performance due to GC throughput limitations. These copies can be eliminating by simply passing the reference of the original Netty ByteBuf which can then be passed to the storage layer and eliminate the need for any Buf to array conversion / rewrapping.

This PR is an initial draft of these changes validated with the unit tests as well as basic long running tests for validity.