### PR TITLE
close writers during end of stage using onStageCompleted

### DIFF
--- a/src/main/java/com/uber/rss/clients/DataBlockSyncWriteClient.java
+++ b/src/main/java/com/uber/rss/clients/DataBlockSyncWriteClient.java
@@ -118,6 +118,25 @@ public class DataBlockSyncWriteClient extends com.uber.rss.clients.ClientBase {
     writeControlMessageNotWaitResponseStatus(startUploadMessage);
   }
 
+  // TODO do not need mapId/taskAttemptId for StartUploadMessage
+  public void startUpload(ShuffleMapTaskAttemptId shuffleMapTaskAttemptId, int stageId, int numMaps, int numPartitions, ShuffleWriteConfig shuffleWriteConfig) {
+    logger.debug(String.format("Starting upload %s, %s", shuffleMapTaskAttemptId, connectionInfo));
+
+    startUploadShuffleByteSnapshot = totalWriteBytes;
+    
+    StartUploadMessage startUploadMessage = new StartUploadMessage(
+            shuffleMapTaskAttemptId.getShuffleId(),
+            shuffleMapTaskAttemptId.getMapId(),
+            shuffleMapTaskAttemptId.getTaskAttemptId(),
+            numMaps,
+            numPartitions,
+            "",
+            shuffleWriteConfig.getNumSplits(),
+            stageId);
+
+    writeControlMessageNotWaitResponseStatus(startUploadMessage);
+  }
+
   public void writeData(int partitionId, long taskAttemptId, ByteBuf data) {
     final int headerByteCount = Integer.BYTES + Long.BYTES + Integer.BYTES;
     final int dataByteCount = data.readableBytes();

--- a/src/main/java/com/uber/rss/clients/NotifyClient.java
+++ b/src/main/java/com/uber/rss/clients/NotifyClient.java
@@ -17,6 +17,7 @@ package com.uber.rss.clients;
 import com.uber.rss.exceptions.RssInvalidStateException;
 import com.uber.rss.messages.FinishApplicationAttemptRequestMessage;
 import com.uber.rss.messages.FinishApplicationJobRequestMessage;
+import com.uber.rss.messages.FinishApplicationStageRequestMessage;
 import com.uber.rss.messages.MessageConstants;
 import com.uber.rss.messages.ConnectNotifyRequest;
 import com.uber.rss.messages.ConnectNotifyResponse;
@@ -76,6 +77,12 @@ public class NotifyClient extends com.uber.rss.clients.ClientBase {
 
   public void finishApplicationAttempt(String appId, String appAttempt) {
     FinishApplicationAttemptRequestMessage request = new FinishApplicationAttemptRequestMessage(appId, appAttempt);
+
+    writeControlMessageAndWaitResponseStatus(request);
+  }
+
+  public void finishApplicationStage(String appId, String appAttempt, int stageId) {
+    FinishApplicationStageRequestMessage request = new FinishApplicationStageRequestMessage(appId, appAttempt, stageId);
 
     writeControlMessageAndWaitResponseStatus(request);
   }

--- a/src/main/java/com/uber/rss/clients/ShuffleDataSyncWriteClientBase.java
+++ b/src/main/java/com/uber/rss/clients/ShuffleDataSyncWriteClientBase.java
@@ -78,7 +78,7 @@ public abstract class ShuffleDataSyncWriteClientBase implements ShuffleDataSyncW
 
   public void startUpload(AppTaskAttemptId appTaskAttemptId, int numMaps, int numPartitions) {
     shuffleMapTaskAttemptId = appTaskAttemptId.getShuffleMapTaskAttemptId();
-    dataBlockSyncWriteClient.startUpload(shuffleMapTaskAttemptId, numMaps, numPartitions, shuffleWriteConfig);
+    dataBlockSyncWriteClient.startUpload(shuffleMapTaskAttemptId, appTaskAttemptId.getStageId(), numMaps, numPartitions, shuffleWriteConfig);
   }
 
   @Override

--- a/src/main/java/com/uber/rss/common/AppTaskAttemptId.java
+++ b/src/main/java/com/uber/rss/common/AppTaskAttemptId.java
@@ -26,6 +26,9 @@ public class AppTaskAttemptId {
     private final int mapId;
     private final long taskAttemptId;
 
+    // if not associated with startUpload pipeline, value will be -1
+    private final int stageId;
+
     public AppTaskAttemptId(AppShuffleId appShuffleId, int mapId, long taskAttemptId) {
         this(appShuffleId.getAppId(), appShuffleId.getAppAttempt(), appShuffleId.getShuffleId(), mapId, taskAttemptId);
     }
@@ -35,11 +38,16 @@ public class AppTaskAttemptId {
     }
 
     public AppTaskAttemptId(String appId, String appAttempt, int shuffleId, int mapId, long taskAttemptId) {
+        this(appId, appAttempt, shuffleId, mapId, taskAttemptId, -1);
+    }
+
+    public AppTaskAttemptId(String appId, String appAttempt, int shuffleId, int mapId, long taskAttemptId, int stageId) {
         this.appId = appId;
         this.appAttempt = appAttempt;
         this.shuffleId = shuffleId;
         this.mapId = mapId;
         this.taskAttemptId = taskAttemptId;
+        this.stageId = stageId;
     }
 
     public String getAppId() {
@@ -74,6 +82,10 @@ public class AppTaskAttemptId {
         return new ShuffleMapTaskAttemptId(shuffleId, mapId, taskAttemptId);
     }
 
+    public int getStageId() {
+        return stageId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -83,13 +95,14 @@ public class AppTaskAttemptId {
                 mapId == that.mapId &&
                 taskAttemptId == that.taskAttemptId &&
                 Objects.equals(appId, that.appId) &&
-                Objects.equals(appAttempt, that.appAttempt);
+                Objects.equals(appAttempt, that.appAttempt) &&
+                stageId == that.stageId;
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(appId, appAttempt, shuffleId, mapId, taskAttemptId);
+        return Objects.hash(appId, appAttempt, shuffleId, mapId, taskAttemptId, stageId);
     }
 
     @Override
@@ -100,6 +113,7 @@ public class AppTaskAttemptId {
                 ", shuffleId=" + shuffleId +
                 ", mapId=" + mapId +
                 ", taskAttemptId=" + taskAttemptId +
+                ", stageId=" + stageId +
                 '}';
     }
 }

--- a/src/main/java/com/uber/rss/decoders/StreamServerMessageDecoder.java
+++ b/src/main/java/com/uber/rss/decoders/StreamServerMessageDecoder.java
@@ -27,6 +27,7 @@ import com.uber.rss.messages.ConnectUploadRequest;
 import com.uber.rss.messages.ConnectUploadResponse;
 import com.uber.rss.messages.FinishApplicationAttemptRequestMessage;
 import com.uber.rss.messages.FinishApplicationJobRequestMessage;
+import com.uber.rss.messages.FinishApplicationStageRequestMessage;
 import com.uber.rss.messages.FinishUploadMessage;
 import com.uber.rss.messages.GetBusyStatusRequest;
 import com.uber.rss.messages.GetBusyStatusResponse;
@@ -359,6 +360,8 @@ public class StreamServerMessageDecoder extends ByteToMessageDecoder {
         return FinishApplicationJobRequestMessage.deserialize(in);
       case MessageConstants.MESSAGE_FinishApplicationAttemptRequest:
         return FinishApplicationAttemptRequestMessage.deserialize(in);
+      case MessageConstants.MESSAGE_FinishApplicationStageRequest:
+        return FinishApplicationStageRequestMessage.deserialize(in);
       case MessageConstants.MESSAGE_ConnectRegistryRequest:
         return ConnectRegistryRequest.deserialize(in);
       case MessageConstants.MESSAGE_ConnectRegistryResponse:

--- a/src/main/java/com/uber/rss/decoders/StreamServerVersionDecoder.java
+++ b/src/main/java/com/uber/rss/decoders/StreamServerVersionDecoder.java
@@ -84,7 +84,7 @@ public class StreamServerVersionDecoder extends ByteToMessageDecoder {
         } else if (type == MessageConstants.NOTIFY_UPLINK_MAGIC_BYTE &&
                 version == MessageConstants.NOTIFY_UPLINK_VERSION_3) {
             newDecoder = new StreamServerMessageDecoder(null);
-            NotifyChannelInboundHandler channelInboundHandler = new NotifyChannelInboundHandler(serverId);
+            NotifyChannelInboundHandler channelInboundHandler = new NotifyChannelInboundHandler(serverId, executor);
             channelInboundHandler.processChannelActive(ctx);
             newHandler = channelInboundHandler;
         } else if (type == MessageConstants.REGISTRY_UPLINK_MAGIC_BYTE &&

--- a/src/main/java/com/uber/rss/exceptions/RssInvalidStageException.java
+++ b/src/main/java/com/uber/rss/exceptions/RssInvalidStageException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2020 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.rss.exceptions;
+
+/***
+ * This exception is thrown where there is an error with a shuffle stage in the shuffle server.
+ * (e.g. the stageId -> shuffleId lookup is passed a stage that doesn't have a mapping)
+ */
+public class RssInvalidStageException extends RssException {
+    public RssInvalidStageException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/uber/rss/handlers/NotifyChannelInboundHandler.java
+++ b/src/main/java/com/uber/rss/handlers/NotifyChannelInboundHandler.java
@@ -15,9 +15,11 @@
 package com.uber.rss.handlers;
 
 import com.uber.rss.exceptions.RssInvalidDataException;
+import com.uber.rss.execution.ShuffleExecutor;
 import com.uber.rss.messages.FinishApplicationAttemptRequestMessage;
 import com.uber.rss.messages.FinishApplicationJobRequestMessage;
 import com.uber.rss.messages.ConnectNotifyRequest;
+import com.uber.rss.messages.FinishApplicationStageRequestMessage;
 import com.uber.rss.metrics.M3Stats;
 import com.uber.rss.util.NettyUtils;
 import io.netty.channel.ChannelHandlerContext;
@@ -33,8 +35,8 @@ public class NotifyChannelInboundHandler extends ChannelInboundHandlerAdapter {
 
     private final NotifyServerHandler serverHandler;
 
-    public NotifyChannelInboundHandler(String serverId) {
-        serverHandler = new NotifyServerHandler(serverId);
+    public NotifyChannelInboundHandler(String serverId, ShuffleExecutor executor) {
+        serverHandler = new NotifyServerHandler(serverId, executor);
     }
 
     @Override
@@ -61,6 +63,8 @@ public class NotifyChannelInboundHandler extends ChannelInboundHandlerAdapter {
                 serverHandler.handleMessage(ctx, (FinishApplicationJobRequestMessage)msg);
             } else if (msg instanceof FinishApplicationAttemptRequestMessage) {
                 serverHandler.handleMessage(ctx, (FinishApplicationAttemptRequestMessage)msg);
+            } else if (msg instanceof FinishApplicationStageRequestMessage) {
+                serverHandler.handleMessage(ctx, (FinishApplicationStageRequestMessage) msg);
             } else {
                 throw new RssInvalidDataException(String.format("Unsupported message: %s, %s", msg, connectionInfo));
             }

--- a/src/main/java/com/uber/rss/handlers/UploadChannelInboundHandler.java
+++ b/src/main/java/com/uber/rss/handlers/UploadChannelInboundHandler.java
@@ -18,6 +18,7 @@ import com.uber.m3.tally.Counter;
 import com.uber.m3.tally.Gauge;
 import com.uber.rss.RssBuildInfo;
 import com.uber.rss.clients.ShuffleWriteConfig;
+import com.uber.rss.common.AppShuffleId;
 import com.uber.rss.common.AppTaskAttemptId;
 import com.uber.rss.exceptions.RssInvalidDataException;
 import com.uber.rss.exceptions.RssMaxConnectionsException;
@@ -178,11 +179,14 @@ public class UploadChannelInboundHandler extends ChannelInboundHandlerAdapter {
                     appAttempt,
                     startUploadMessage.getShuffleId(),
                     startUploadMessage.getMapId(),
-                    startUploadMessage.getAttemptId());
+                    startUploadMessage.getAttemptId(),
+                    startUploadMessage.getStageId());
 
                 ShuffleWriteConfig writeConfig = new ShuffleWriteConfig(startUploadMessage.getNumSplits());
                 uploadServerHandler.initializeAppTaskAttempt(appTaskAttemptId, startUploadMessage.getNumPartitions(),
                                                                 writeConfig, ctx);
+                uploadServerHandler.registerStageId(startUploadMessage.getStageId(),
+                        new AppShuffleId(appId, appAttempt, startUploadMessage.getShuffleId()));
             } else if (msg instanceof FinishUploadMessage) {
                 logger.debug("FinishUploadMessage, {}, {}", msg, connectionInfo);
                 FinishUploadMessage finishUploadMessage = (FinishUploadMessage)msg;

--- a/src/main/java/com/uber/rss/handlers/UploadServerHandler.java
+++ b/src/main/java/com/uber/rss/handlers/UploadServerHandler.java
@@ -16,8 +16,10 @@ package com.uber.rss.handlers;
 
 import com.uber.rss.clients.ShuffleWriteConfig;
 import com.uber.rss.common.AppMapId;
+import com.uber.rss.common.AppShuffleId;
 import com.uber.rss.common.AppTaskAttemptId;
 import com.uber.rss.exceptions.RssInvalidDataException;
+import com.uber.rss.exceptions.RssInvalidStageException;
 import com.uber.rss.exceptions.RssInvalidStateException;
 import com.uber.rss.exceptions.RssMaxConnectionsException;
 import com.uber.rss.execution.ShuffleDataWrapper;
@@ -117,6 +119,17 @@ public class UploadServerHandler {
         AppMapId appMapId = getAppMapId(taskAttemptId);
         AppTaskAttemptId appTaskAttemptIdToFinishUpload = new AppTaskAttemptId(appMapId, taskAttemptId);
         finishUploadImpl(appTaskAttemptIdToFinishUpload);
+    }
+
+    public void registerStageId(int stageId, AppShuffleId appShuffleId) {
+        // stageId default is -1. this would only occur in cases if method not called for StartUploadMessage or error occurred
+        if (stageId != -1) {
+            executor.registerShuffleId(stageId, appShuffleId);
+        } else {
+            String error = String.format("registerStageId called not using StartUploadMessage or stageId never set for shuffle=%s", appShuffleId);
+            logger.error(error);
+            throw new RssInvalidStageException(error);
+        }
     }
 
     private void finishUploadImpl(AppTaskAttemptId appTaskAttemptIdToFinishUpload) {

--- a/src/main/java/com/uber/rss/messages/FinishApplicationStageRequestMessage.java
+++ b/src/main/java/com/uber/rss/messages/FinishApplicationStageRequestMessage.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.rss.messages;
+
+import com.uber.rss.util.ByteBufUtils;
+import io.netty.buffer.ByteBuf;
+
+/**
+ * Notifies RSS when a Spark Stage is completed.
+ */
+public class FinishApplicationStageRequestMessage extends ControlMessage {
+    private final String appId;
+    private final String appAttempt;
+    private final int stageId;
+
+    public FinishApplicationStageRequestMessage(String appId, String appAttempt, int stageId) {
+        this.appId = appId;
+        this.appAttempt = appAttempt;
+        this.stageId = stageId;
+    }
+
+    @Override
+    public int getMessageType() {
+        return MessageConstants.MESSAGE_FinishApplicationStageRequest;
+    }
+
+    @Override
+    public void serialize(ByteBuf buf) {
+        ByteBufUtils.writeLengthAndString(buf, appId);
+        ByteBufUtils.writeLengthAndString(buf, appAttempt);
+        buf.writeInt(stageId);
+    }
+
+    public static FinishApplicationStageRequestMessage deserialize(ByteBuf buf) {
+        String appId = ByteBufUtils.readLengthAndString(buf);
+        String appAttempt = ByteBufUtils.readLengthAndString(buf);
+        int stageId = buf.readInt();
+        return new FinishApplicationStageRequestMessage(appId, appAttempt, stageId);
+    }
+
+    public String getAppId() {
+        return appId;
+    }
+
+    public String getAppAttempt() {
+        return appAttempt;
+    }
+
+    public int getStageId() {
+        return stageId;
+    }
+
+    @Override
+    public String toString() {
+        return "FinishApplicationStageRequestMessage{" +
+                "appId='" + appId + '\'' +
+                ", appAttempt='" + appAttempt + '\'' +
+                ", stageId=" + stageId +
+                '}';
+    }
+}

--- a/src/main/java/com/uber/rss/messages/MessageConstants.java
+++ b/src/main/java/com/uber/rss/messages/MessageConstants.java
@@ -38,6 +38,7 @@ public class MessageConstants {
     public final static int MESSAGE_RegisterServerRequest = -9;
     public final static int MESSAGE_GetServersRequest = -10;
     public final static int MESSAGE_FinishApplicationJobRequest = -12;
+    public final static int MESSAGE_FinishApplicationStageRequest = -13;
 
     public final static int MESSAGE_GetServersResponse = -16;
     public final static int MESSAGE_RegisterServerResponse = -19;

--- a/src/main/java/com/uber/rss/messages/StartUploadMessage.java
+++ b/src/main/java/com/uber/rss/messages/StartUploadMessage.java
@@ -19,15 +19,20 @@ import io.netty.buffer.ByteBuf;
 
 public class StartUploadMessage extends BaseMessage {
 
-    private int shuffleId;
-    private int mapId;
-    private long attemptId;
-    private int numMaps;
-    private int numPartitions;
-    private String fileCompressionCodec;
-    private short numSplits;
+    private final int shuffleId;
+    private final int mapId;
+    private final long attemptId;
+    private final int numMaps;
+    private final int numPartitions;
+    private final String fileCompressionCodec;
+    private final short numSplits;
+    private final int stageId;
 
     public StartUploadMessage(int shuffleId, int mapId, long attemptId, int numMaps, int numPartitions, String fileCompressionCodec, short numSplits) {
+        this(shuffleId, mapId, attemptId, numMaps, numPartitions, fileCompressionCodec, numSplits, -1);
+    }
+
+    public StartUploadMessage(int shuffleId, int mapId, long attemptId, int numMaps, int numPartitions, String fileCompressionCodec, short numSplits, int stageId) {
         this.shuffleId = shuffleId;
         this.mapId = mapId;
         this.attemptId = attemptId;
@@ -35,6 +40,7 @@ public class StartUploadMessage extends BaseMessage {
         this.numPartitions = numPartitions;
         this.fileCompressionCodec = fileCompressionCodec;
         this.numSplits = numSplits;
+        this.stageId = stageId;
     }
 
     @Override
@@ -51,6 +57,7 @@ public class StartUploadMessage extends BaseMessage {
         buf.writeInt(numPartitions);
         ByteBufUtils.writeLengthAndString(buf, fileCompressionCodec);
         buf.writeShort(numSplits);
+        buf.writeInt(stageId);
     }
 
     public static StartUploadMessage deserialize(ByteBuf buf) {
@@ -61,7 +68,8 @@ public class StartUploadMessage extends BaseMessage {
         int numPartitions = buf.readInt();
         String fileCompressionCodec = ByteBufUtils.readLengthAndString(buf);
         short numSplits = buf.readShort();
-        return new StartUploadMessage(shuffleId, mapId, attemptId, numMaps, numPartitions, fileCompressionCodec, numSplits);
+        int stageId = buf.readInt();
+        return new StartUploadMessage(shuffleId, mapId, attemptId, numMaps, numPartitions, fileCompressionCodec, numSplits, stageId);
     }
 
     public int getShuffleId() {
@@ -92,6 +100,10 @@ public class StartUploadMessage extends BaseMessage {
         return numSplits;
     }
 
+    public int getStageId() {
+        return stageId;
+    }
+
     @Override
     public String toString() {
         return "StartUploadMessage{" +
@@ -102,6 +114,7 @@ public class StartUploadMessage extends BaseMessage {
             ", numPartitions=" + numPartitions +
             ", fileCompressionCodec='" + fileCompressionCodec + '\'' +
             ", numSplits=" + numSplits +
+            ", stageId= " + stageId +
             '}';
     }
 }

--- a/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssOpts.scala
@@ -177,4 +177,9 @@ object RssOpts {
       .doc("Create lazy connections from mappers to RSS servers just before sending the shuffle data")
       .booleanConf
       .createWithDefault(true)
+  val enableListenForOnStageCompleted: ConfigEntry[Boolean] =
+    ConfigBuilder("spark.shuffle.rss.enableListenForOnStageCompleted")
+      .doc("Tell RSS to process onStageCompleted events from SparkListener")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/src/main/scala/org/apache/spark/shuffle/RssShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssShuffleManager.scala
@@ -118,6 +118,7 @@ class RssShuffleManager(conf: SparkConf) extends ShuffleManager with Logging {
 
     RssSparkListener.registerSparkListenerOnlyOnce(sparkContext, () =>
       new RssSparkListener(
+        conf,
         user,
         conf.getAppId,
         appAttempt,
@@ -158,7 +159,8 @@ class RssShuffleManager(conf: SparkConf) extends ShuffleManager with Logging {
           rssShuffleHandle.appAttempt,
           handle.shuffleId,
           mapId,
-          context.taskAttemptId()
+          context.taskAttemptId(),
+          context.stageId()
         )
 
         logDebug( s"getWriter $mapInfo" )

--- a/src/test/java/com/uber/rss/clients/NotifyClientTest.java
+++ b/src/test/java/com/uber/rss/clients/NotifyClientTest.java
@@ -56,4 +56,21 @@ public class NotifyClientTest {
         }
     }
 
+    @Test
+    public void finishApplicationStage() {
+        TestStreamServer testServer = TestStreamServer.createRunningServer();
+
+        try (NotifyClient client = new NotifyClient("localhost", testServer.getShufflePort(), TestConstants.NETWORK_TIMEOUT, "user1")) {
+            client.connect();
+            // send same request twice to make sure it is still good
+            client.finishApplicationStage("app1", "exec1", 1);
+            client.finishApplicationStage("app1", "exec1", 1);
+            // send different request to make sure it is still good
+            client.finishApplicationStage("app1", "exec2", 2);
+            client.finishApplicationStage("app2", "exec2", 2);
+        } finally {
+            testServer.shutdown();
+        }
+    }
+
 }


### PR DESCRIPTION
Improvement on when to close writers. While implementing an s3 storage engine, noticed that we want to close the writers sooner than later to ensure shuffle files are stored on s3 by the end of a stage. 