### PR TITLE
[WIP] Add tolerance in RSS cluster for server going away

### DIFF
--- a/patch/0001-RSS-fault-tolerance-patch.patch
+++ b/patch/0001-RSS-fault-tolerance-patch.patch
@@ -1,0 +1,1091 @@
+From adbbaad401766b0f629d80dd351dcaa6dbcda5a3 Mon Sep 17 00:00:00 2001
+From: Mayur Bhosale <mayurb@uber.com>
+Date: Sun, 19 Mar 2023 23:59:37 +0530
+Subject: [PATCH] RSS fault tolerance patch
+
+---
+ .../scala/org/apache/spark/Dependency.scala   |  10 +-
+ .../spark/internal/config/package.scala       |  47 ++++
+ .../apache/spark/scheduler/DAGScheduler.scala |  75 ++++-
+ .../org/apache/spark/scheduler/Stage.scala    |  15 +-
+ .../spark/scheduler/StageRetryHook.scala      |  27 ++
+ .../org/apache/spark/scheduler/TaskInfo.scala |  10 +
+ .../spark/scheduler/TaskSchedulerImpl.scala   |  37 ++-
+ .../spark/scheduler/TaskSetManager.scala      |   9 +-
+ .../org/apache/spark/util/ShuffleUtil.scala   |  34 +++
+ .../scala/org/apache/spark/util/Utils.scala   |  13 +
+ .../spark/scheduler/DAGSchedulerSuite.scala   | 261 ++++++++++++++++++
+ .../spark/scheduler/StageRetryHookSuite.scala | 182 ++++++++++++
+ .../scheduler/TaskSchedulerImplSuite.scala    | 100 +++++++
+ 13 files changed, 811 insertions(+), 9 deletions(-)
+ create mode 100644 core/src/main/scala/org/apache/spark/scheduler/StageRetryHook.scala
+ create mode 100644 core/src/main/scala/org/apache/spark/util/ShuffleUtil.scala
+ create mode 100644 core/src/test/scala/org/apache/spark/scheduler/StageRetryHookSuite.scala
+
+diff --git a/core/src/main/scala/org/apache/spark/Dependency.scala b/core/src/main/scala/org/apache/spark/Dependency.scala
+index 9ea6d2fa2f..0aabd71401 100644
+--- a/core/src/main/scala/org/apache/spark/Dependency.scala
++++ b/core/src/main/scala/org/apache/spark/Dependency.scala
+@@ -90,10 +90,14 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
+ 
+   val shuffleId: Int = _rdd.context.newShuffleId()
+ 
+-  val shuffleHandle: ShuffleHandle = _rdd.context.env.shuffleManager.registerShuffle(
+-    shuffleId, _rdd.partitions.length, this)
++  var shuffleHandle: ShuffleHandle = null
+ 
+-  _rdd.sparkContext.cleaner.foreach(_.registerShuffleForCleanup(this))
++  def registerShuffle(): Unit = {
++    shuffleHandle = _rdd.context.env.shuffleManager
++      .registerShuffle(shuffleId, _rdd.partitions.length, this)
++    }
++
++  registerShuffle()
+ }
+ 
+ 
+diff --git a/core/src/main/scala/org/apache/spark/internal/config/package.scala b/core/src/main/scala/org/apache/spark/internal/config/package.scala
+index 4e5b8f044a..8d395fc6a5 100644
+--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
++++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
+@@ -153,6 +153,53 @@ package object config {
+   private[spark] val SHUFFLE_SERVICE_PORT =
+     ConfigBuilder("spark.shuffle.service.port").intConf.createWithDefault(7337)
+ 
++  private[spark] val SHUFFLE_RSS_FETCH_FAILED_CLEAR_ALL_MAP_STATUS =
++    ConfigBuilder("spark.shuffle.rss.clearAllMapOutputOnStageRetry")
++      .doc("Clear map outputs of the all previously succeeded tasks from " +
++        "Shuffle Map Stage when a task fails with FetchFail")
++      .booleanConf.createWithDefault(false)
++
++  private[spark] val STAGE_RETRY_HOOK =
++    ConfigBuilder("spark.shuffle.stage.retryHook")
++      .doc("Add an externally pluggable hook which will be triggered before the re-attempt" +
++        "of a stage")
++      .stringConf
++      .createWithDefault("")
++
++  private[spark] val STAGE_RETRY_HOOK_ENABLED =
++    ConfigBuilder("spark.shuffle.retry.trigger.enabled")
++      .doc("Enable Stage retry hook")
++      .booleanConf
++      .createWithDefault(false)
++
++  private[spark] val SHUFFLE_RSS_CLEAR_INTERMEDIATE_MAP_OUTPUT =
++    ConfigBuilder("spark.shuffle.rss.clearIntermediateMapOutputs")
++      .doc("Clear map outputs of the all previously succeeded tasks from " +
++        "Shuffle Map Stage just before submitting tasks from re-attempt of the stage." +
++        "Once the map outputs are cleared by SHUFFLE_RSS_FETCH_FAILED_CLEAR_ALL_MAP_STATUS," +
++        "few tasks from previous attempt might still succeed. This ensures that those attempts" +
++        "are not considered")
++      .booleanConf.createWithDefault(false)
++
++  private[spark] val SHUFFLE_RSS_MARK_OLD_STAGE_ATTEMPTS_STALE =
++    ConfigBuilder("spark.shuffle.rss.markOldStageAttemptsStale")
++      .doc("Mark old stage attempts of a stage stale whenever a new attempt of " +
++        "the stage is created to not consider old task completion towards partition completion." +
++        "Once all the tasks of the shuffle map stage are submitted, few tasks from the old" +
++        "attempt might still succeed, and tasks for the corresponding partition in new attempt" +
++        "will be ignored. This ensures that such laggard tasks are not considered.")
++      .booleanConf
++      .createWithDefault(false)
++
++  private[spark] val SHUFFLE_SKIP_SUCCEEDED_FAILED_STAGE =
++    ConfigBuilder("spark.shuffle.skipSucceededFailedShuffleMapStages")
++      .doc("Failed task from shuffle map stage can come even when a retry of the stage has " +
++        "already started/succeeded. In such cases submitted Shuffle map stage anyways " +
++        "completes with no pending tasks. This is an unnecessary overhead on DAGSchedulee " +
++        "and also causes issue with fault tolerant RSS.")
++      .booleanConf
++      .createWithDefault(true)
++
+   private[spark] val KEYTAB = ConfigBuilder("spark.yarn.keytab")
+     .doc("Location of user's keytab.")
+     .stringConf.createOptional
+diff --git a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+index 18baa0b73c..ad9424aa4f 100644
+--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
++++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+@@ -38,6 +38,7 @@ import org.apache.spark.broadcast.Broadcast
+ import org.apache.spark.executor.TaskMetrics
+ import org.apache.spark.internal.Logging
+ import org.apache.spark.internal.config
++import org.apache.spark.internal.config.{SHUFFLE_RSS_MARK_OLD_STAGE_ATTEMPTS_STALE, SHUFFLE_SKIP_SUCCEEDED_FAILED_STAGE}
+ import org.apache.spark.network.util.JavaUtils
+ import org.apache.spark.partial.{ApproximateActionListener, ApproximateEvaluator, PartialResult}
+ import org.apache.spark.rdd.{DeterministicLevel, RDD, RDDCheckpointData}
+@@ -224,6 +225,12 @@ private[spark] class DAGScheduler(
+     sc.getConf.getInt("spark.stage.maxConsecutiveAttempts",
+       DAGScheduler.DEFAULT_MAX_CONSECUTIVE_STAGE_ATTEMPTS)
+ 
++  private val markOldStageAttemptsStale =
++    sc.conf.get(SHUFFLE_RSS_MARK_OLD_STAGE_ATTEMPTS_STALE)
++
++  private val skipSucceededFailedStages =
++    sc.conf.get(SHUFFLE_SKIP_SUCCEEDED_FAILED_STAGE)
++
+   /**
+    * Number of max concurrent tasks check failures for each barrier job.
+    */
+@@ -881,8 +888,20 @@ private[spark] class DAGScheduler(
+       // the ResubmitFailedStages event has been scheduled.
+       logInfo("Resubmitting failed stages")
+       clearCacheLocs()
+-      val failedStagesCopy = failedStages.toArray
++      val failedStagesSkipped = new HashSet[Stage]
++      val failedStagesCopy = failedStages.toArray.filter(stage => stage match {
++        case shuffleMapStage: ShuffleMapStage
++          if skipSucceededFailedStages && shuffleMapStage.isAvailable =>
++          logInfo(s"Not submitting failed stage ${stage.id} since it has " +
++            s"already completed")
++          failedStagesSkipped.add(shuffleMapStage)
++          false
++        case _ =>
++          true
++      })
+       failedStages.clear()
++      // Submit child stages of skipped failed stages
++      failedStagesSkipped.foreach(submitWaitingChildStages(_))
+       for (stage <- failedStagesCopy.sortBy(_.firstJobId)) {
+         submitStage(stage)
+       }
+@@ -1106,6 +1125,19 @@ private[spark] class DAGScheduler(
+   private def submitMissingTasks(stage: Stage, jobId: Int) {
+     logDebug("submitMissingTasks(" + stage + ")")
+ 
++    // Before find missing partition, do the intermediate state clean work first.
++    // Since the RSS server mapping can change during the retry, so the operation here
++    // will make sure `findMissingPartitions()` returns all partitions every time.
++    stage match {
++      case sms: ShuffleMapStage
++        if ShuffleUtil.isUsingRSSForShuffle(sms.shuffleDep.shuffleHandle, sc.conf) &&
++          sc.conf.get(config.SHUFFLE_RSS_CLEAR_INTERMEDIATE_MAP_OUTPUT) && !sms.isAvailable =>
++        logInfo(s"Removing all RSS reported map status for stage: ${stage.id} and " +
++          s"shuffle ${sms.shuffleDep.shuffleId}")
++        mapOutputTracker.unregisterAllMapOutput(sms.shuffleDep.shuffleId)
++      case _ =>
++    }
++
+     // First figure out the indexes of partition ids to compute.
+     val partitionsToCompute: Seq[Int] = stage.findMissingPartitions()
+ 
+@@ -1405,18 +1437,31 @@ private[spark] class DAGScheduler(
+             }
+ 
+           case smt: ShuffleMapTask =>
++            val shouldIgnoreTask = event.taskInfo.isTaskAttemptStale ||
++              (markOldStageAttemptsStale &&
++                isShuffleMapStageRunningOnRss(stageId) &&
++                (task.stageAttemptId < stage.latestInfo.attemptNumber()))
+             val shuffleStage = stage.asInstanceOf[ShuffleMapStage]
+-            shuffleStage.pendingPartitions -= task.partitionId
++            if (!shouldIgnoreTask) {
++              shuffleStage.pendingPartitions -= task.partitionId
++            }
+             val status = event.result.asInstanceOf[MapStatus]
+             val execId = status.location.executorId
+             logDebug("ShuffleMapTask finished on " + execId)
+             if (executorFailureEpoch.contains(execId) &&
+                 smt.epoch <= executorFailureEpoch(execId)) {
+               logInfo(s"Ignoring possibly bogus $smt completion from executor $execId")
++            } else if (shouldIgnoreTask) {
++              // If any mew attempt of stage has started
++              logInfo(s"Not registering shuffle map task ${event.taskInfo.id} with map output " +
++                s"tracker as there is already attempt of the task running from new stage attempt")
+             } else {
+               // The epoch of the task is acceptable (i.e., the task was launched after the most
+               // recent failure we're aware of for the executor), so mark the task's output as
+               // available.
++              logDebug(s"Registering shuffle map output: " +
++                s"shuffleId: ${shuffleStage.shuffleDep.shuffleId}, " +
++                s"partitionId: ${smt.partitionId}")
+               mapOutputTracker.registerMapOutput(
+                 shuffleStage.shuffleDep.shuffleId, smt.partitionId, status)
+             }
+@@ -1487,6 +1532,14 @@ private[spark] class DAGScheduler(
+           } else if (mapId != -1) {
+             // Mark the map whose fetch failed as broken in the map stage
+             mapOutputTracker.unregisterMapOutput(shuffleId, mapId, bmAddress)
++          } else if (sc.conf.get(config.SHUFFLE_RSS_FETCH_FAILED_CLEAR_ALL_MAP_STATUS) &&
++            ShuffleUtil.isUsingRSSForShuffle(mapStage.shuffleDep.shuffleHandle, sc.conf) &&
++            !waitingStages(stage)) {
++            // In push based shuffle, fetch failure is mainly caused by the entire storage
++            // server going down. Currently, there is no way of knowing all the maps which
++            // wrote shuffle data to this server, so clear all the map outputs instead.
++            logInfo(s"Removing all RSS reported map status for shuffle $shuffleId")
++            mapOutputTracker.unregisterAllMapOutput(shuffleId)
+           }
+ 
+           if (failedStage.rdd.isBarrier()) {
+@@ -2078,6 +2131,24 @@ private[spark] class DAGScheduler(
+     taskScheduler.stop()
+   }
+ 
++  /**
++   * If the stage is a ShuffleMapStage running on Rss
++   */
++  def isShuffleMapStageRunningOnRss(stageId: Int): Boolean = {
++    if (Utils.isTesting && sc.conf.getBoolean("spark.shuffle.test.mockRss", false)) {
++      true
++    } else {
++      stageIdToStage.get(stageId) match {
++        case Some(_: ResultStage) =>
++          false
++        case Some(stage: ShuffleMapStage) =>
++          ShuffleUtil.isUsingRSSForShuffle(stage.shuffleDep.shuffleHandle, sc.conf)
++        case _ =>
++          false
++      }
++    }
++  }
++
+   eventProcessLoop.start()
+ }
+ 
+diff --git a/core/src/main/scala/org/apache/spark/scheduler/Stage.scala b/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
+index 26cca334d3..71cc2a07d7 100644
+--- a/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
++++ b/core/src/main/scala/org/apache/spark/scheduler/Stage.scala
+@@ -21,8 +21,9 @@ import scala.collection.mutable.HashSet
+ 
+ import org.apache.spark.executor.TaskMetrics
+ import org.apache.spark.internal.Logging
++import org.apache.spark.internal.config.{STAGE_RETRY_HOOK, STAGE_RETRY_HOOK_ENABLED}
+ import org.apache.spark.rdd.RDD
+-import org.apache.spark.util.CallSite
++import org.apache.spark.util.{CallSite, Utils}
+ 
+ /**
+  * A stage is a set of parallel tasks all computing the same function that need to run as part
+@@ -81,6 +82,15 @@ private[scheduler] abstract class Stage(
+    */
+   private var _latestInfo: StageInfo = StageInfo.fromStage(this, nextAttemptId)
+ 
++  lazy val stageRetryHook: Option[StageRetryHook] = {
++    rdd.conf.getOption(STAGE_RETRY_HOOK.key) match {
++      case Some(retryHookClass) if retryHookClass != "" =>
++        Utils.instantiateClass[StageRetryHook](retryHookClass)
++      case _ =>
++        None
++    }
++  }
++
+   /**
+    * Set of stage attempt IDs that have failed. We keep track of these failures in order to avoid
+    * endless retries if a stage keeps failing.
+@@ -101,6 +111,9 @@ private[scheduler] abstract class Stage(
+     metrics.register(rdd.sparkContext)
+     _latestInfo = StageInfo.fromStage(
+       this, nextAttemptId, Some(numPartitionsToCompute), metrics, taskLocalityPreferences)
++    if (nextAttemptId != 0 && rdd.conf.get(STAGE_RETRY_HOOK_ENABLED)) {
++      stageRetryHook.map(_.beforeStageRetryHookSync(this))
++    }
+     nextAttemptId += 1
+   }
+ 
+diff --git a/core/src/main/scala/org/apache/spark/scheduler/StageRetryHook.scala b/core/src/main/scala/org/apache/spark/scheduler/StageRetryHook.scala
+new file mode 100644
+index 0000000000..4e3db32639
+--- /dev/null
++++ b/core/src/main/scala/org/apache/spark/scheduler/StageRetryHook.scala
+@@ -0,0 +1,27 @@
++/*
++ * Licensed to the Apache Software Foundation (ASF) under one or more
++ * contributor license agreements.  See the NOTICE file distributed with
++ * this work for additional information regarding copyright ownership.
++ * The ASF licenses this file to You under the Apache License, Version 2.0
++ * (the "License"); you may not use this file except in compliance with
++ * the License.  You may obtain a copy of the License at
++ *
++ *    http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++package org.apache.spark.scheduler
++
++/**
++ * Interface for externally pluggable before stage retry hook.
++ *
++ * Currently, getting used by RSS for calling registerShuffle before retrying the ShuffleMapStage
++ *  so that a fresh list of RSS servers is picked.
++ */
++trait StageRetryHook {
++  def beforeStageRetryHookSync(stageToBeRetried: Stage): Unit
++}
+diff --git a/core/src/main/scala/org/apache/spark/scheduler/TaskInfo.scala b/core/src/main/scala/org/apache/spark/scheduler/TaskInfo.scala
+index 9843eab4f1..f2e9baa117 100644
+--- a/core/src/main/scala/org/apache/spark/scheduler/TaskInfo.scala
++++ b/core/src/main/scala/org/apache/spark/scheduler/TaskInfo.scala
+@@ -40,6 +40,10 @@ class TaskInfo(
+     val taskLocality: TaskLocality.TaskLocality,
+     val speculative: Boolean) {
+ 
++  // Used to identify if another attempt for this index is already running on
++  //  latest attempt of the stage
++  private var isStaleAttempt: Boolean = false
++
+   /**
+    * The time when the task started remotely getting the result. Will not be set if the
+    * task result was sent immediately when the task finished (as opposed to sending an
+@@ -122,4 +126,10 @@ class TaskInfo(
+   }
+ 
+   private[spark] def timeRunning(currentTime: Long): Long = currentTime - launchTime
++
++  def markAsStaleAttempt: Unit = {
++    isStaleAttempt = true
++  }
++
++  def isTaskAttemptStale: Boolean = isStaleAttempt
+ }
+diff --git a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+index f6c855589a..0141c04c55 100644
+--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
++++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSchedulerImpl.scala
+@@ -30,6 +30,7 @@ import org.apache.spark._
+ import org.apache.spark.TaskState.TaskState
+ import org.apache.spark.internal.Logging
+ import org.apache.spark.internal.config
++import org.apache.spark.internal.config.SHUFFLE_RSS_MARK_OLD_STAGE_ATTEMPTS_STALE
+ import org.apache.spark.rpc.RpcEndpoint
+ import org.apache.spark.scheduler.SchedulingMode.SchedulingMode
+ import org.apache.spark.scheduler.TaskLocality.TaskLocality
+@@ -91,6 +92,8 @@ private[spark] class TaskSchedulerImpl(
+   // CPUs to request per task
+   val CPUS_PER_TASK = conf.getInt("spark.task.cpus", 1)
+ 
++  val MARK_OLD_STAGE_ATTEMPTS_STALE = conf.get(SHUFFLE_RSS_MARK_OLD_STAGE_ATTEMPTS_STALE)
++
+   // TaskSetManagers are not thread safe, so any access to one should be synchronized
+   // on this class.
+   private val taskSetsByStageIdAndAttempt = new HashMap[Int, HashMap[Int, TaskSetManager]]
+@@ -219,8 +222,17 @@ private[spark] class TaskSchedulerImpl(
+       // and somehow it has missing map outputs, then DAGScheduler will resubmit it and create a
+       // TSM3 for it. As a stage can't have more than one active task set managers, we must mark
+       // TSM2 as zombie (it actually is).
++      val shouldMarkTaskSetStale = MARK_OLD_STAGE_ATTEMPTS_STALE &&
++        isShuffleStageOnRss(tasks.head.stageId)
++
+       stageTaskSets.foreach { case (_, ts) =>
+         ts.isZombie = true
++        if (shouldMarkTaskSetStale) {
++          // Mark the older TSMs as stale before adding new TSM to the stageTaskSets map
++          logInfo(s"Marking task set for Stage: ${ts.stageId}, " +
++            s"Attempt: ${ts.taskSet.stageAttemptId} as stale")
++          ts.markAsStale()
++        }
+       }
+       stageTaskSets(taskSet.stageAttemptId) = manager
+       schedulableBuilder.addTaskSetManager(manager, manager.taskSet.properties)
+@@ -865,12 +877,33 @@ private[spark] class TaskSchedulerImpl(
+   private[scheduler] def markPartitionCompletedInAllTaskSets(
+       stageId: Int,
+       partitionId: Int,
+-      taskInfo: TaskInfo) = {
+-    taskSetsByStageIdAndAttempt.getOrElse(stageId, Map()).values.foreach { tsm =>
++      taskInfo: TaskInfo,
++      taskSetManager: TaskSetManager) = {
++
++    if (taskSetManager.isStale) {
++      // TSM is stale, mark task as stale
++      logDebug(s"Marking task attempt ${taskInfo.id} as stale since new attempt of " +
++        s"the stage is already running")
++      taskInfo.markAsStaleAttempt
++    }
++    var stageAttemptIdsToTsm = taskSetsByStageIdAndAttempt.getOrElse(stageId, Map())
++    if (MARK_OLD_STAGE_ATTEMPTS_STALE && isShuffleStageOnRss(stageId)) {
++      stageAttemptIdsToTsm =
++        stageAttemptIdsToTsm.filter(_._1 < taskSetManager.taskSet.stageAttemptId)
++    }
++    stageAttemptIdsToTsm.values.foreach { tsm =>
+       tsm.markPartitionCompleted(partitionId, taskInfo)
+     }
+   }
+ 
++  private[scheduler] def isShuffleStageOnRss(stageId: Int) = {
++    Option(dagScheduler.isShuffleMapStageRunningOnRss(stageId)) match {
++      case Some(value) =>
++        value
++      case _ =>
++        false
++    }
++  }
+ }
+ 
+ 
+diff --git a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+index 459f575ba7..202205fa9f 100644
+--- a/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
++++ b/core/src/main/scala/org/apache/spark/scheduler/TaskSetManager.scala
+@@ -154,6 +154,9 @@ private[spark] class TaskSetManager(
+   // Set containing all pending tasks (also used as a stack, as above).
+   private val allPendingTasks = new ArrayBuffer[Int]
+ 
++  // Used to identify if there is already a new attempt of the corressponding stage running
++  private[scheduler] var isStale = false
++
+   // Tasks that can be speculated. Since these will be a small fraction of total
+   // tasks, we'll just hold them in a HashSet.
+   private[scheduler] val speculatableTasks = new HashSet[Int]
+@@ -188,6 +191,10 @@ private[spark] class TaskSetManager(
+     addPendingTask(i)
+   }
+ 
++  private[scheduler] def markAsStale(): Unit = {
++    isStale = true
++  }
++
+   /**
+    * Track the set of locality levels which are valid given the tasks locality preferences and
+    * the set of currently available executors.  This is updated as executors are added and removed.
+@@ -785,7 +792,7 @@ private[spark] class TaskSetManager(
+     }
+     // There may be multiple tasksets for this stage -- we let all of them know that the partition
+     // was completed.  This may result in some of the tasksets getting completed.
+-    sched.markPartitionCompletedInAllTaskSets(stageId, tasks(index).partitionId, info)
++    sched.markPartitionCompletedInAllTaskSets(stageId, tasks(index).partitionId, info, this)
+     // This method is called by "TaskSchedulerImpl.handleSuccessfulTask" which holds the
+     // "TaskSchedulerImpl" lock until exiting. To avoid the SPARK-7655 issue, we should not
+     // "deserialize" the value when holding a lock to avoid blocking other threads. So we call
+diff --git a/core/src/main/scala/org/apache/spark/util/ShuffleUtil.scala b/core/src/main/scala/org/apache/spark/util/ShuffleUtil.scala
+new file mode 100644
+index 0000000000..35c6e6f771
+--- /dev/null
++++ b/core/src/main/scala/org/apache/spark/util/ShuffleUtil.scala
+@@ -0,0 +1,34 @@
++/*
++ * Licensed to the Apache Software Foundation (ASF) under one or more
++ * contributor license agreements.  See the NOTICE file distributed with
++ * this work for additional information regarding copyright ownership.
++ * The ASF licenses this file to You under the Apache License, Version 2.0
++ * (the "License"); you may not use this file except in compliance with
++ * the License.  You may obtain a copy of the License at
++ *
++ *    http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++package org.apache.spark.util
++
++import org.apache.spark.SparkConf
++import org.apache.spark.shuffle.ShuffleHandle
++
++object ShuffleUtil {
++
++  /**
++   * Even with the conf spark.shuffle.manager set to org.apache.spark.shuffle.RssShuffleManager,
++   * we fallback to sort shuffle in few cases, so check the class name of ShuffleHandle to get the
++   * shuffle implementation being used.
++   */
++  def isUsingRSSForShuffle(shuffleHandle: ShuffleHandle, conf: SparkConf): Boolean = {
++    shuffleHandle.getClass.getName.equals("org.apache.spark.shuffle.RssShuffleHandle") ||
++      (Utils.isTesting && conf.getBoolean("spark.shuffle.test.mockRss", false))
++  }
++}
+diff --git a/core/src/main/scala/org/apache/spark/util/Utils.scala b/core/src/main/scala/org/apache/spark/util/Utils.scala
+index 8a349e0227..5be6b48ac4 100644
+--- a/core/src/main/scala/org/apache/spark/util/Utils.scala
++++ b/core/src/main/scala/org/apache/spark/util/Utils.scala
+@@ -2895,6 +2895,19 @@ private[spark] object Utils extends Logging {
+     props.asScala.foreach(entry => resultProps.put(entry._1, entry._2))
+     resultProps
+   }
++
++  def instantiateClass[T](className: String): Option[T] = {
++    try {
++      val cls = Utils.classForName(className)
++      Option(cls.getConstructor()
++        .newInstance()
++        .asInstanceOf[T])
++    } catch {
++      case NonFatal(e) =>
++        logWarning(s"Ignoring error while initializing class: $className. ${e.getMessage}")
++        None
++    }
++  }
+ }
+ 
+ private[util] object CallerContext extends Logging {
+diff --git a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+index 562853f322..6156ab813b 100644
+--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
++++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+@@ -1141,6 +1141,267 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
+     assert(results === Map(0 -> 42))
+   }
+ 
++  test("Only reduce stage should be retried on a resubmitted attempt of stage caused by" +
++    "  FetchFailure in RSS SPARKBL-2") {
++    sc.conf.set("spark.shuffle.rss.clearAllMapOutputOnStageRetry", "false")
++    sc.conf.set("spark.shuffle.service.enabled", "false")
++    val shuffleMapRdd = new MyRDD(sc, 2, Nil)
++    val shuffleDep = new ShuffleDependency(shuffleMapRdd, new HashPartitioner(2))
++    val shuffleId = shuffleDep.shuffleId
++    val reduceRdd = new MyRDD(sc, 2, List(shuffleDep), tracker = mapOutputTracker)
++    submit(reduceRdd, Array(0, 1))
++    complete(taskSets(0), Seq(
++      (Success, makeMapStatus("hostA", reduceRdd.partitions.length)),
++      (Success, makeMapStatus("hostB", reduceRdd.partitions.length))))
++    assert(mapOutputTracker.findMissingPartitions(shuffleId) === Some(Seq.empty))
++
++    // The first result task fails, with a fetch failure for the output from the first mapper.
++    runEvent(makeCompletionEvent(
++      taskSets(1).tasks(0),
++      // RSS passes dummy executor id while throwing fetchFailed
++      FetchFailed(makeBlockManagerId("dummyHost"), shuffleId, -1, 0, "ignored"),
++      null))
++
++    // Since map id was passed as -1, output of all mappers should be available
++    assert(mapOutputTracker.findMissingPartitions(shuffleId) === Some(Seq.empty))
++
++    scheduler.resubmitFailedStages()
++
++    // Complete the result stage.
++    completeNextResultStageWithSuccess(1, 1)
++
++    sc.listenerBus.waitUntilEmpty(WAIT_TIMEOUT_MILLIS)
++    assertDataStructuresEmpty()
++  }
++
++  test("With cleanAllMapOutputStatus enabled, both map and reduce stage should be " +
++    "  retried on a resubmitted attempt of stage caused by FetchFailure in RSS SPARKBL-2") {
++    sc.conf.set("spark.shuffle.rss.clearAllMapOutputOnStageRetry", "true")
++    sc.conf.set("spark.shuffle.test.mockRss", "true")
++    sc.conf.set("spark.shuffle.service.enabled", "false")
++    val shuffleMapRdd = new MyRDD(sc, 2, Nil)
++    val shuffleDep = new ShuffleDependency(shuffleMapRdd, new HashPartitioner(2))
++    val shuffleId = shuffleDep.shuffleId
++    val reduceRdd = new MyRDD(sc, 2, List(shuffleDep), tracker = mapOutputTracker)
++    submit(reduceRdd, Array(0, 1))
++    complete(taskSets(0), Seq(
++      (Success, makeMapStatus("hostA", reduceRdd.partitions.length)),
++      (Success, makeMapStatus("hostB", reduceRdd.partitions.length))))
++    assert(mapOutputTracker.findMissingPartitions(shuffleId) === Some(Seq.empty))
++
++    // The first result task fails, with a fetch failure for the output from the first mapper.
++    runEvent(makeCompletionEvent(
++      taskSets(1).tasks(0),
++      // RSS passes dummy executor id while throwing fetchFailed
++      FetchFailed(makeBlockManagerId("dummyHost"), shuffleId, -1, 0, "ignored"),
++      null))
++
++    // Map output for all partitions should be missing
++    assert(mapOutputTracker.findMissingPartitions(shuffleId) === Some(Seq(0, 1)))
++
++    scheduler.resubmitFailedStages()
++
++    // Complete the map stage.
++    completeShuffleMapStageSuccessfully(0, 1, numShufflePartitions = 2)
++
++    // Complete the result stage.
++    completeNextResultStageWithSuccess(1, 1)
++
++    sc.listenerBus.waitUntilEmpty(WAIT_TIMEOUT_MILLIS)
++    assertDataStructuresEmpty()
++  }
++
++  test("Scenario: Task from the reduce stage previous attempt fails after few tasks from" +
++    " the new attempt of map stage have already finished: SPARKBL-188") {
++    sc.conf.set("spark.shuffle.rss.clearAllMapOutputOnStageRetry", "true")
++    sc.conf.set("spark.shuffle.test.mockRss", "true")
++    sc.conf.set("spark.shuffle.service.enabled", "false")
++    val shuffleMapRdd = new MyRDD(sc, 2, Nil)
++    val shuffleDep = new ShuffleDependency(shuffleMapRdd, new HashPartitioner(2))
++    val shuffleId = shuffleDep.shuffleId
++    val reduceRdd = new MyRDD(sc, 2, List(shuffleDep), tracker = mapOutputTracker)
++    submit(reduceRdd, Array(0, 1))
++
++    // Complete map stage attempt 0
++    complete(taskSets(0), Seq(
++      (Success, makeMapStatus("hostA", reduceRdd.partitions.length)),
++      (Success, makeMapStatus("hostB", reduceRdd.partitions.length))))
++    assert(mapOutputTracker.findMissingPartitions(shuffleId) === Some(Seq.empty))
++
++    // The first result stage task fails with a fetch failure for the output from the first mapper.
++    runEvent(makeCompletionEvent(
++      taskSets(1).tasks(0),
++      // RSS passes dummy executor id while throwing fetchFailed
++      FetchFailed(makeBlockManagerId("dummyHost"), shuffleId, -1, 0, "ignored"),
++      null))
++
++    // Map output for all partitions should be missing
++    assert(mapOutputTracker.findMissingPartitions(shuffleId) === Some(Seq(0, 1)))
++
++    scheduler.resubmitFailedStages()
++
++    // Complete a map task 0 from map stage attempt 1
++    runEvent(makeCompletionEvent(
++      taskSets(2).tasks(0), Success,
++      makeMapStatus("hostA", reduceRdd.partitions.length),
++      Seq.empty, createFakeTaskInfoWithId(1)))
++
++    // Fail the task of reduce stage attempt 0
++    runEvent(makeCompletionEvent(
++      taskSets(1).tasks(1),
++      // RSS passes dummy executor id while throwing fetchFailed
++      FetchFailed(makeBlockManagerId("dummyHost"), shuffleId, -1, 1, "ignored"),
++      null))
++
++    // Task 0 of the Map stage attempt 1 has already completed, so only map output of task 1
++    // should be missing
++    assert(mapOutputTracker.findMissingPartitions(shuffleId) === Some(Seq(1)))
++
++    // Complete a map task 1 from map stage attempt 1
++    runEvent(makeCompletionEvent(
++      taskSets(2).tasks(1), Success,
++      makeMapStatus("hostB", reduceRdd.partitions.length),
++      Seq.empty, createFakeTaskInfoWithId(1)))
++
++    // Map output of all map tasks from the Map stage attempt 1 should be available
++    assert(mapOutputTracker.findMissingPartitions(shuffleId) === Some(Seq.empty))
++
++    // Resubmit failed stages if any
++    scheduler.resubmitFailedStages()
++
++    // Complete the result stage attempt 1
++    completeNextResultStageWithSuccess(1, 1)
++
++    sc.listenerBus.waitUntilEmpty(WAIT_TIMEOUT_MILLIS)
++    assertDataStructuresEmpty()
++  }
++
++  test("Scenario: Task from the reduce stage previous attempt fails after the new attempt of" +
++    " map stage has already completed: SPARKBL-188") {
++    sc.conf.set("spark.shuffle.rss.clearAllMapOutputOnStageRetry", "true")
++    sc.conf.set("spark.shuffle.test.mockRss", "true")
++    sc.conf.set("spark.shuffle.service.enabled", "false")
++    val shuffleMapRdd = new MyRDD(sc, 2, Nil)
++    val shuffleDep = new ShuffleDependency(shuffleMapRdd, new HashPartitioner(2))
++    val shuffleId = shuffleDep.shuffleId
++    val reduceRdd = new MyRDD(sc, 2, List(shuffleDep), tracker = mapOutputTracker)
++    submit(reduceRdd, Array(0, 1))
++
++    // Complete map stage attempt 0
++    complete(taskSets(0), Seq(
++      (Success, makeMapStatus("hostA", reduceRdd.partitions.length)),
++      (Success, makeMapStatus("hostB", reduceRdd.partitions.length))))
++    assert(mapOutputTracker.findMissingPartitions(shuffleId) === Some(Seq.empty))
++
++    // The first result stage task fails with a fetch failure for the output from the first mapper.
++    runEvent(makeCompletionEvent(
++      taskSets(1).tasks(0),
++      // RSS passes dummy executor id while throwing fetchFailed
++      FetchFailed(makeBlockManagerId("dummyHost"), shuffleId, -1, 0, "ignored"),
++      null))
++
++    // Map output for all partitions should be missing
++    assert(mapOutputTracker.findMissingPartitions(shuffleId) === Some(Seq(0, 1)))
++
++    scheduler.resubmitFailedStages()
++
++    // Complete a map task 0 from map stage attempt 1
++    runEvent(makeCompletionEvent(
++      taskSets(2).tasks(0), Success,
++      makeMapStatus("hostA", reduceRdd.partitions.length),
++      Seq.empty, createFakeTaskInfoWithId(1)))
++
++    // Complete a map task 1 from map stage attempt 1
++    runEvent(makeCompletionEvent(
++      taskSets(2).tasks(1), Success,
++      makeMapStatus("hostB", reduceRdd.partitions.length),
++      Seq.empty, createFakeTaskInfoWithId(1)))
++
++    // Map output of all map tasks from the Map stage attempt 1 should be available
++    assert(mapOutputTracker.findMissingPartitions(shuffleId) === Some(Seq.empty))
++
++    // Fail the task of reduce stage attempt 0
++    runEvent(makeCompletionEvent(
++      taskSets(1).tasks(1),
++      // RSS passes dummy executor id while throwing fetchFailed
++      FetchFailed(makeBlockManagerId("dummyHost"), shuffleId, -1, 1, "ignored"),
++      null))
++
++    // Mapout of all map tasks should still be available
++    assert(mapOutputTracker.findMissingPartitions(shuffleId) === Some(Seq.empty))
++
++    // Resubmit failed stages if any
++    scheduler.resubmitFailedStages()
++
++    // Complete the result stage attempt 1
++    completeNextResultStageWithSuccess(1, 1)
++
++    sc.listenerBus.waitUntilEmpty(WAIT_TIMEOUT_MILLIS)
++    assertDataStructuresEmpty()
++  }
++
++  test("Do not re-submit already completed shuffle map stage") {
++    setupStageAbortTest(sc)
++
++    val parts = 8
++    val shuffleMapRdd = new MyRDD(sc, parts, Nil)
++    val shuffleDep = new ShuffleDependency(shuffleMapRdd, new HashPartitioner(parts))
++    val reduceRdd = new MyRDD(sc, parts, List(shuffleDep), tracker = mapOutputTracker)
++    submit(reduceRdd, (0 until parts).toArray)
++
++    val shuffleMapStage = scheduler.stageIdToStage(0)
++    val resultStage = scheduler.stageIdToStage(1)
++
++    // Add shuffleMapStage and resultStage to failed stages
++    scheduler.failedStages += shuffleMapStage
++    scheduler.failedStages += resultStage
++
++    // only shuffleMapStage 0 should be running
++    assert(scheduler.runningStages.size == 1)
++    assert(scheduler.runningStages.contains(shuffleMapStage))
++    // resultStage should be waiting
++    assert(scheduler.waitingStages.size == 1)
++    assert(scheduler.waitingStages.contains(resultStage))
++    // shuffleMapStage and resultStage should be present in failed
++    assert(scheduler.failedStages.size == 2)
++    assert(Seq(shuffleMapStage, resultStage).forall(scheduler.failedStages.contains(_)))
++
++    // Complete the shuffle map stage
++    completeShuffleMapStageSuccessfully(0, 0, numShufflePartitions = parts)
++
++    // running/waiting stages should be empty: waiting resultStage was picked but could not
++    // get scheduled because its also present in failed stages list
++    assert(scheduler.runningStages.isEmpty)
++    assert(scheduler.waitingStages.isEmpty)
++    // shuffleMapStage and resultStage should be in failed stages
++    assert(scheduler.failedStages.size == 2)
++    assert(Seq(shuffleMapStage, resultStage).forall(scheduler.failedStages.contains(_)))
++
++    // Resubmit failed stage
++    scheduler.resubmitFailedStages()
++
++    // resultStage should be running
++    // there should be no waiting stage
++    // there should be no failed stage
++    assert(scheduler.runningStages.size == 1)
++    assert(scheduler.runningStages.contains(resultStage))
++    assert(scheduler.waitingStages.isEmpty)
++    assert(scheduler.failedStages.isEmpty)
++
++    // Complete the result stage
++    completeNextResultStageWithSuccess(1, 0)
++
++    assert(scheduler.runningStages.isEmpty)
++    assert(scheduler.waitingStages.isEmpty)
++    assert(scheduler.failedStages.isEmpty)
++
++    // Confirm job finished successfully
++    sc.listenerBus.waitUntilEmpty(1000)
++    assert(ended === true)
++    assert(results === (0 until parts).map { idx => idx -> 42 }.toMap)
++    assertDataStructuresEmpty()
++  }
++
+   test("trivial shuffle with multiple fetch failures") {
+     val shuffleMapRdd = new MyRDD(sc, 2, Nil)
+     val shuffleDep = new ShuffleDependency(shuffleMapRdd, new HashPartitioner(2))
+diff --git a/core/src/test/scala/org/apache/spark/scheduler/StageRetryHookSuite.scala b/core/src/test/scala/org/apache/spark/scheduler/StageRetryHookSuite.scala
+new file mode 100644
+index 0000000000..7d0c1f42a6
+--- /dev/null
++++ b/core/src/test/scala/org/apache/spark/scheduler/StageRetryHookSuite.scala
+@@ -0,0 +1,182 @@
++/*
++ * Licensed to the Apache Software Foundation (ASF) under one or more
++ * contributor license agreements.  See the NOTICE file distributed with
++ * this work for additional information regarding copyright ownership.
++ * The ASF licenses this file to You under the Apache License, Version 2.0
++ * (the "License"); you may not use this file except in compliance with
++ * the License.  You may obtain a copy of the License at
++ *
++ *    http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++package org.apache.spark.scheduler
++
++import org.scalatest.BeforeAndAfter
++
++import org.apache.spark._
++import org.apache.spark.rdd.RDD
++import org.apache.spark.shuffle.FetchFailedException
++import org.apache.spark.util.ShuffleUtil
++
++
++class StageRetryHookSuite extends SparkFunSuite with BeforeAndAfter with LocalSparkContext {
++
++  def getShuffleDep(rdd: RDD[_]): ShuffleDependency[_, _, _] = {
++    rdd.dependencies.find(_.isInstanceOf[ShuffleDependency[_, _, _]])
++      .get
++      .asInstanceOf[ShuffleDependency[_, _, _]]
++  }
++
++  test("Same shuffle manager instance should be used on stage retry with no retry hook") {
++    val conf = new SparkConf(loadDefaults = false)
++    conf.set("spark.shuffle.test.mockRss", "true")
++    conf.set("spark.shuffle.retry.trigger.enabled", "true")
++
++    sc = new SparkContext("local", "test", conf)
++    val rdd = sc.makeRDD(1 to 1)
++      .map(t => (t/2) -> (t*2).longValue())
++      .reduceByKey(_ + _)
++
++    val shuffleDep = getShuffleDep(rdd)
++    val initialShuffleHandle = shuffleDep.shuffleHandle
++    val shuffleId = shuffleDep.shuffleId
++
++    rdd.mapPartitions(partition => {
++      val stageAttemptNumber = TaskContext.get().stageAttemptNumber()
++      if (stageAttemptNumber <= 1) {
++        throw new FetchFailedException(null, shuffleId, -1, -1, "Force send exception")
++      }
++      partition
++    }).collect()
++
++    val shuffleHandleAfterRetry = getShuffleDep(rdd).shuffleHandle
++    assert(initialShuffleHandle == shuffleHandleAfterRetry)
++  }
++
++  test("New shuffle manager instance should be created on stage retry with custom retry hook") {
++    val conf = new SparkConf(loadDefaults = false)
++    conf.set("spark.shuffle.test.mockRss", "true")
++    conf.set("spark.shuffle.retry.trigger.enabled", "true")
++    conf.set("spark.shuffle.stage.retryHook", "org.apache.spark.scheduler.DummyStageRetryHook")
++    conf.set("spark.shuffle.skipSucceededFailedShuffleMapStages", "false")
++
++    sc = new SparkContext("local", "test", conf)
++    val rdd = sc.makeRDD(1 to 1)
++      .map(t => (t/2) -> (t*2).longValue())
++      .reduceByKey(_ + _)
++
++    val shuffleDep = getShuffleDep(rdd)
++    val initialShuffleHandle = shuffleDep.shuffleHandle
++    val shuffleId = shuffleDep.shuffleId
++
++    rdd.mapPartitions(partition => {
++      val stageAttemptNumber = TaskContext.get().stageAttemptNumber()
++      if (stageAttemptNumber <= 1) {
++        throw new FetchFailedException(null, shuffleId, -1, -1, "Force send exception")
++      }
++      partition
++    }).collect()
++
++    val shuffleHandleAfterRetry = getShuffleDep(rdd).shuffleHandle
++    assert(initialShuffleHandle != shuffleHandleAfterRetry)
++  }
++
++  test("Same shuffle manager instance should be used when StageRetryHook " +
++    "is passed but not available") {
++    val conf = new SparkConf(loadDefaults = false)
++    conf.set("spark.shuffle.test.mockRss", "true")
++    conf.set("spark.shuffle.retry.trigger.enabled", "true")
++    conf.set("spark.shuffle.stage.retryHook", "org.apache.spark.scheduler.BadStageRetryHook")
++
++    sc = new SparkContext("local", "test", conf)
++    val rdd = sc.makeRDD(1 to 1)
++      .map(t => (t/2) -> (t*2).longValue())
++      .reduceByKey(_ + _)
++
++    val shuffleDep = getShuffleDep(rdd)
++    val initialShuffleHandle = shuffleDep.shuffleHandle
++    val shuffleId = shuffleDep.shuffleId
++
++    rdd.mapPartitions(partition => {
++      val stageAttemptNumber = TaskContext.get().stageAttemptNumber()
++      if (stageAttemptNumber <= 1) {
++        throw new FetchFailedException(null, shuffleId, -1, -1, "Force send exception")
++      }
++      partition
++    }).collect()
++
++    val shuffleHandleAfterRetry = getShuffleDep(rdd).shuffleHandle
++    assert(initialShuffleHandle == shuffleHandleAfterRetry)
++  }
++
++  test("Same shuffle manager instance should be used when shuffle manager is not RSS") {
++    val conf = new SparkConf(loadDefaults = false)
++    conf.set("spark.shuffle.test.mockRss", "false")
++    conf.set("spark.shuffle.retry.trigger.enabled", "true")
++    conf.set("spark.shuffle.stage.retryHook", "org.apache.spark.scheduler.DummyStageRetryHook")
++    conf.set("spark.shuffle.skipSucceededFailedShuffleMapStages", "false")
++
++    sc = new SparkContext("local", "test", conf)
++    val rdd = sc.makeRDD(1 to 1)
++      .map(t => (t/2) -> (t*2).longValue())
++      .reduceByKey(_ + _)
++
++    val shuffleDep = getShuffleDep(rdd)
++    val initialShuffleHandle = shuffleDep.shuffleHandle
++    val shuffleId = shuffleDep.shuffleId
++
++    rdd.mapPartitions(partition => {
++      val stageAttemptNumber = TaskContext.get().stageAttemptNumber()
++      if (stageAttemptNumber <= 1) {
++        throw new FetchFailedException(null, shuffleId, -1, -1, "Force send exception")
++      }
++      partition
++    }).collect()
++
++    val shuffleHandleAfterRetry = getShuffleDep(rdd).shuffleHandle
++    assert(initialShuffleHandle == shuffleHandleAfterRetry)
++  }
++
++  test("Same shuffle manager instance should get used since SMS is already available, so it" +
++    " will not get re-submitted") {
++    val conf = new SparkConf(loadDefaults = false)
++    conf.set("spark.shuffle.test.mockRss", "true")
++    conf.set("spark.shuffle.retry.trigger.enabled", "true")
++    conf.set("spark.shuffle.stage.retryHook", "org.apache.spark.scheduler.DummyStageRetryHook")
++    conf.set("spark.shuffle.rss.clearIntermediateMapOutputs", "true")
++    sc = new SparkContext("local", "test", conf)
++    val rdd = sc.makeRDD(1 to 1)
++      .map(t => (t/2) -> (t*2).longValue())
++      .reduceByKey(_ + _)
++    val shuffleDep = getShuffleDep(rdd)
++    val initialShuffleHandle = shuffleDep.shuffleHandle
++    val shuffleId = shuffleDep.shuffleId
++    rdd.mapPartitions(partition => {
++      val stageAttemptNumber = TaskContext.get().stageAttemptNumber()
++      if (stageAttemptNumber <= 1) {
++        throw new FetchFailedException(null, shuffleId, 0, -1, "Force send exception")
++      }
++      partition
++    }).collect()
++    val shuffleHandleAfterRetry = getShuffleDep(rdd).shuffleHandle
++    assert(initialShuffleHandle == shuffleHandleAfterRetry)
++  }
++}
++
++class DummyStageRetryHook extends StageRetryHook {
++  override def beforeStageRetryHookSync(stageToBeRetried: Stage): Unit = {
++    stageToBeRetried match {
++      // Only use when RSS is the shuffle manager
++      case stage: ShuffleMapStage if ShuffleUtil.isUsingRSSForShuffle
++      (stage.shuffleDep.shuffleHandle, stage.rdd.conf) =>
++        stage.shuffleDep.registerShuffle()
++      case _ =>
++    }
++  }
++}
+diff --git a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+index ecbb6ab519..6faf766513 100644
+--- a/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
++++ b/core/src/test/scala/org/apache/spark/scheduler/TaskSchedulerImplSuite.scala
+@@ -1221,6 +1221,106 @@ class TaskSchedulerImplSuite extends SparkFunSuite with LocalSparkContext with B
+     }
+   }
+ 
++  test("SPARKBL-757-1") {
++    // Completion in zombie tasks should not kill task attempts of latest stage
++
++    val taskScheduler = setupSchedulerWithMockTaskSetBlacklist(
++      ("spark.shuffle.rss.markOldStageAttemptsStale", "true"),
++      ("spark.shuffle.test.mockRss", "true"))
++    dagScheduler.sc.conf.set("spark.shuffle.test.mockRss", "true")
++
++    val valueSer = SparkEnv.get.serializer.newInstance()
++
++    def completeTaskSuccessfully(tsm: TaskSetManager, partition: Int): Unit = {
++      val indexInTsm = tsm.partitionToIndex(partition)
++      val matchingTaskInfo = tsm.taskAttempts.flatten.filter(_.index == indexInTsm).head
++      val result = new DirectTaskResult[Int](valueSer.serialize(1), Seq())
++      tsm.handleSuccessfulTask(matchingTaskInfo.taskId, result)
++    }
++
++    // Submit a task set, have it fail with a fetch failed, and then re-submit the task attempt,
++    // two times, so we have three active task sets for one stage.  (For this to really happen,
++    // you'd need the previous stage to also get restarted, and then succeed, in between each
++    // attempt, but that happens outside what we're mocking here.)
++
++    val zombieAttempt = {
++      val attempt =
++        FakeTask.createTaskSet(10, stageId = 0, stageAttemptId = 0, priority = 0)
++      taskScheduler.submitTasks(attempt)
++      val tsm = taskScheduler.taskSetManagerForAttempt(0, 0).get
++      val offers = (0 until 10).map{ idx => WorkerOffer(s"exec-$idx", s"host-$idx", 1) }
++      taskScheduler.resourceOffers(offers)
++      assert(tsm.runningTasks === 10)
++      // fail attempt 0
++      tsm.handleFailedTask(tsm.taskAttempts.head.head.taskId, TaskState.FAILED,
++        FetchFailed(null, 0, 0, 0, "fetch failed"))
++      // the attempt is a zombie, but the tasks are still running (this could be true even if
++      // we actively killed those tasks, as killing is best-effort)
++      assert(tsm.isZombie)
++      assert(tsm.runningTasks === 9)
++      tsm
++    }
++
++    val finalAttempt =
++      FakeTask.createTaskSet(10, stageId = 1, stageAttemptId = 1, priority = 0)
++    taskScheduler.submitTasks(finalAttempt)
++    val finalTsm = taskScheduler.taskSetManagerForAttempt(0, 1).get
++    val offers = (0 until 5).map{ idx => WorkerOffer(s"exec-$idx", s"host-$idx", 1) }
++    val finalAttemptLaunchedPartitionsInitial = taskScheduler.resourceOffers(offers).flatten
++      .map { task => finalAttempt.tasks(task.index).partitionId}.toSet
++    assert(finalTsm.runningTasks === 5)
++    assert(!finalTsm.isZombie)
++
++    // We simulate late completions from our zombie tasksets, corresponding to all the pending
++    // partitions in our final attempt.  This means we're only waiting on the tasks we've already
++    // launched.
++    val finalAttemptPendingPartitions =
++    (0 until 10).toSet.diff(finalAttemptLaunchedPartitionsInitial)
++
++    // old attempt should have been marked as stale
++    assert(zombieAttempt.isStale)
++
++    finalAttemptPendingPartitions.foreach { partition =>
++      completeTaskSuccessfully(zombieAttempt, partition)
++    }
++
++    // For the tasks which finished from older attempt, should be marked as stale
++    assert(zombieAttempt.taskInfos.values
++      .filter(taskInfo => {
++        finalAttemptPendingPartitions.contains(taskInfo.index) && taskInfo.index != 0
++      })
++      .forall(_.isTaskAttemptStale))
++
++    // Finish submitted tasks on the finalTsm
++    finalAttemptLaunchedPartitionsInitial.foreach { partition =>
++      completeTaskSuccessfully(finalTsm, partition)
++    }
++
++    // Make 5 resource offers for remaining tasks from finalTSM
++    val newOffers = (0 until 5).map{ idx => WorkerOffer(s"exec-$idx", s"host-$idx", 1) }
++    val finalAttemptLaunchedPartitionsLater = taskScheduler.resourceOffers(newOffers).flatten
++      .map { task => finalAttempt.tasks(task.index).partitionId}.toSet
++
++    assert(finalAttemptLaunchedPartitionsLater == finalAttemptPendingPartitions)
++
++    // Finish these tasks on the finalTsk
++    finalAttemptLaunchedPartitionsLater.foreach { partition =>
++      completeTaskSuccessfully(finalTsm, partition)
++    }
++
++    assert(finalTsm.tasksSuccessful == 10)
++    assert(finalTsm.taskInfos.values.forall(taskInfo => finalTsm.successful(taskInfo.index)))
++
++    // All the finished tasks from finalTsm should mark all the attempts of the
++    // zombieTsm as done
++    // (except for one which failed with FetchFail)
++    assert(zombieAttempt.tasksSuccessful == 10)
++    assert(zombieAttempt.taskInfos.values
++      .filter(taskInfo => finalAttemptLaunchedPartitionsLater.contains(taskInfo.index) &&
++        taskInfo.index != 0)
++      .forall(x => zombieAttempt.successful(x.index)))
++  }
++
+   test("don't schedule for a barrier taskSet if available slots are less than pending tasks") {
+     val taskCpus = 2
+     val taskScheduler = setupScheduler("spark.task.cpus" -> taskCpus.toString)
+-- 
+2.37.1
+

--- a/src/main/scala/org/apache/spark/scheduler/RssStageRetryHook.scala
+++ b/src/main/scala/org/apache/spark/scheduler/RssStageRetryHook.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler
+
+import org.apache.spark.shuffle.rss.RssUtils
+
+//class RssStageRetryHook extends StageRetryHook {
+
+  /**
+   * If RSS is the shuffle manager, call registerShuffle() on shuffle dependency so that
+   * a fresh list of RSS servers is picked.
+   */
+//  override def beforeStageRetryHookSync(stageToBeRetried: Stage): Unit = {
+//    stageToBeRetried match {
+//      case stage: ShuffleMapStage if RssUtils.isUsingRSSForShuffle
+//      (stage.shuffleDep.shuffleHandle, stage.rdd.conf) =>
+//        StageRetryHookMetrics.getInstance(stage.rdd.conf).incStageRetryHookTriggeredMetrics(stage.id)
+//        stage.shuffleDep.registerShuffle()
+//      case _ =>
+//    }
+//  }
+//}

--- a/src/main/scala/org/apache/spark/shuffle/rss/RssUtils.scala
+++ b/src/main/scala/org/apache/spark/shuffle/rss/RssUtils.scala
@@ -14,13 +14,6 @@
 
 package org.apache.spark.shuffle.rss
 
-import java.util
-import java.util.function.Supplier
-
-import com.uber.rss.clients._
-import com.uber.rss.common.{MapTaskRssInfo, ServerDetail, ServerList, ServerReplicationGroup}
-import com.uber.rss.exceptions.{RssException, RssInvalidMapStatusException}
-import com.uber.rss.util.RetryUtils
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.storage.BlockManagerId
@@ -133,5 +126,9 @@ object RssUtils extends Logging {
     val dummyHost = "dummy_host"
     val dummyPort = 99999
     BlockManagerId(s"reduce_${shuffleId}_$partition", dummyHost, dummyPort, None)
+  }
+
+  def isUsingRSSForShuffle(shuffleHandle: ShuffleHandle, conf: SparkConf): Boolean = {
+    shuffleHandle.getClass.getName.equals("org.apache.spark.shuffle.RssShuffleHandle")
   }
 }


### PR DESCRIPTION
Adds fault tolerance in RSS servers for one or more server going away. This is how the functionality works

- Node/server goes away
- Task reading/writing data from that server fail
- Code throws a fetch failed exception in both read/write flow
- If its a shuffle map stage, patch  added in spark takes care of rolling back the stage completely and retry the required stages: if fetch fail is thrown when reading shuffle data, retry current and parent stage, if fetch fail is thrown when writing shuffle data, retry only the current stage
- A stage retry hook is added in the patch which gets triggered before the stage is retried. Hook's implementation in RSS calls the registerShuffle again for this particular shuffle
- A new list of available servers is picked
- As in the normal flow, set of RSS servers to be used is sent to mappers and reducers as part of shuffle handle


In the spark patch, new interface is added for the stage retry hook. I won't be able to add UTs without these changes in spark binary. Maybe we can upload a fat jar in the repo for that.

Also, there is a [patch](https://issues.apache.org/jira/browse/SPARK-25341) added in open source for rolling back shuffle map stage in Spark 3.0, I haven't yet evaluated that. Maybe we can make use of it to avoid the long changes here. I'll evaluate and get back on that.