### PR TITLE
Fix Rss getReader mapIdx bug

### DIFF
--- a/src/main/scala/org/apache/spark/shuffle/RssShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/RssShuffleManager.scala
@@ -294,7 +294,7 @@ class RssShuffleManager(conf: SparkConf) extends ShuffleManager with Logging {
 
   // This method is called in Spark executor, getting information from Spark driver via the ShuffleHandle.
   override def getReader[K, C](handle: ShuffleHandle, startMapIndex: Int, endMapIndex: Int, startPartition: Int, endPartition: Int, context: TaskContext, metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {
-    getReaderForRange(handle, 0, Integer.MAX_VALUE, startPartition, endPartition, context, metrics)
+    getReaderForRange(handle, startMapIndex, endMapIndex, startPartition, endPartition, context, metrics)
   }
 
   def getReaderForRange[K, C](handle: ShuffleHandle, startMapIndex: Int, endMapIndex: Int, startPartition: Int, endPartition: Int, context: TaskContext, metrics: ShuffleReadMetricsReporter): ShuffleReader[K, C] = {


### PR DESCRIPTION
Pass the startmapIndex and endMapIdx to getReaderForRange. And with this change, the AQE realted issues are fixed https://github.com/uber/RemoteShuffleService/issues/99